### PR TITLE
fix: floating panel detection, auto-open, company extraction, cover l…

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -42,10 +42,20 @@
         "*://*.icims.com/*",
         "*://*.jobvite.com/*",
         "*://*.taleo.net/*",
+        "*://*.recruitingbypaycor.com/*",
+        "*://*.paylocity.com/*",
+        "*://*.paycomonline.com/*",
+        "*://*.eightfold.ai/*",
+        "*://*.breezy.hr/*",
+        "*://*.fountainhq.com/*",
+        "*://*.dayforce.com/*",
         "*://linkedin.com/jobs/*",
         "*://www.linkedin.com/jobs/*",
         "*://indeed.com/viewjob*",
-        "*://www.indeed.com/viewjob*"
+        "*://www.indeed.com/viewjob*",
+        "*://careers.*.*/*",
+        "*://jobs.*.*/*",
+        "*://apply.*.*/*"
       ],
       "js": ["content/floatingPanel.js"],
       "run_at": "document_idle"

--- a/extension/src/background/worker.ts
+++ b/extension/src/background/worker.ts
@@ -39,9 +39,21 @@ const CAREER_URL_PATTERNS = [
   /wellfound\.com\/jobs/,
   /otta\.com/,
   /gh_jid=/,
+  /recruitingbypaycor\.com/,
+  /paylocity\.com/,
+  /paycomonline\.com/,
+  /ultipro\.com/,
+  /successfactors\.com/,
+  /eightfold\.ai/,
+  /breezy\.hr/,
+  /fountainhq\.com/,
+  /dayforce\.com/,
   /careers\.[a-z]+\.[a-z]+/,
   /[a-z]+\.com\/careers\//,
   /[a-z]+\.com\/jobs\//,
+  /[a-z]+\.com\/apply\//,
+  /\/job-application/,
+  /\/job_application/,
 ];
 
 const JOB_SCOUT_PATTERNS = [
@@ -106,24 +118,36 @@ function classifyUrl(url: string): "apply" | "scout" | null {
 }
 
 function extractCompanyFromUrl(url: string, title: string): string {
-  // Try hostname first: "careers.google.com" → "Google"
+  const ATS_SUBDOMAINS = new Set(["greenhouse", "lever", "workday", "myworkday", "ashbyhq",
+    "smartrecruiters", "bamboohr", "icims", "jobvite", "taleo", "recruitingbypaycor",
+    "paylocity", "eightfold", "breezy"]);
+  const SKIP_PREFIXES = new Set(["careers", "jobs", "apply", "hiring", "work", "talent", "recruit", "job"]);
+
   try {
     const hostname = new URL(url).hostname.replace(/^www\./, "");
     const parts = hostname.split(".");
-    // "careers.google.com" → "google"
-    if (parts[0] === "careers" || parts[0] === "jobs") {
-      return parts[1] ? parts[1].charAt(0).toUpperCase() + parts[1].slice(1) : "";
-    }
     // "google.greenhouse.io" → "Google"
-    if (parts.length >= 3 && (parts[1] === "greenhouse" || parts[1] === "lever")) {
-      return parts[0].charAt(0).toUpperCase() + parts[0].slice(1);
+    if (parts.length >= 3 && ATS_SUBDOMAINS.has(parts[1] ?? "")) {
+      const name = parts[0] ?? "";
+      return name.split(/[-_]/).map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+    }
+    // "careers.frazierdeeter.com" → "Frazierdeeter"
+    if (SKIP_PREFIXES.has(parts[0] ?? "")) {
+      const name = parts[1] ?? "";
+      return name.split(/[-_]/).map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+    }
+    // "frazierdeeter.com/careers/..." → "Frazierdeeter"
+    const tld = parts[parts.length - 1] ?? "";
+    const domain = parts[parts.length - 2] ?? "";
+    if (tld.length <= 3 && domain && !SKIP_PREFIXES.has(domain)) {
+      return domain.split(/[-_]/).map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
     }
   } catch {
     // ignore
   }
 
   // Fall back to page title: "Software Engineer at Google" → "Google"
-  const atMatch = title.match(/\bat\s+([A-Z][a-zA-Z\s]+?)(?:\s*[\-–|]|$)/);
+  const atMatch = title.match(/\bat\s+([A-Z][a-zA-Z0-9\s&.,'()-]+?)(?:\s*[\-–|·]|$)/);
   if (atMatch) return atMatch[1].trim();
 
   return "";
@@ -198,8 +222,13 @@ chrome.runtime.onMessage.addListener(
         const tabId = sender.tab?.id;
         if (tabId) {
           // Store heuristically-detected context if not already known (URL didn't match patterns)
-          if (!tabContexts.has(tabId) && message.context) {
+          if (message.context) {
             tabContexts.set(tabId, message.context);
+            // Relay to sidepanel so it updates immediately (may already be open)
+            chrome.runtime.sendMessage<Message>({
+              type: "PAGE_CONTEXT_UPDATE",
+              payload: message.context,
+            }).catch(() => {});
           }
           chrome.sidePanel.open({ tabId }).catch(() => {});
         }

--- a/extension/src/content/detector.ts
+++ b/extension/src/content/detector.ts
@@ -38,6 +38,22 @@ function getFieldLabel(el: HTMLElement): string {
     parent = parent.parentElement;
   }
 
+  // Check field wrapper with class-based label
+  const wrapper = el.closest("[class*='field'], [class*='Field'], [class*='form-group'], [class*='form-item'], [class*='FormItem'], [class*='FormField']");
+  if (wrapper) {
+    const wrapperLabel = wrapper.querySelector("label, legend, [class*='label'], [class*='Label']");
+    if (wrapperLabel && wrapperLabel !== el) {
+      const text = wrapperLabel.textContent?.trim() || "";
+      if (text) return text;
+    }
+  }
+  // Check previous sibling for label text
+  const prev = el.previousElementSibling;
+  if (prev && ["SPAN", "DIV", "LABEL", "P"].includes(prev.tagName)) {
+    const text = prev.textContent?.trim() || "";
+    if (text && text.length < 80) return text;
+  }
+
   return el.getAttribute("name") || "";
 }
 
@@ -63,14 +79,14 @@ function classifyField(el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectEl
 function detectFields(): DetectedField[] {
   const inputs = Array.from(
     document.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
-      "input:not([type=hidden]):not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]), select"
+      "input:not([type=hidden]):not([type=submit]):not([type=button]), select"
     )
   );
   const fields: DetectedField[] = [];
 
   for (const el of inputs) {
     const fieldType = classifyField(el as HTMLInputElement);
-    if (fieldType === "unknown") continue;
+    if (fieldType === "unknown" && !getFieldLabel(el as HTMLElement)) continue;
 
     fields.push({
       fieldId: el.id || el.name || `field_${fields.length}`,
@@ -425,7 +441,9 @@ export function detectJobPageHeuristic(): boolean {
     'textarea',
   ].filter(selector => document.querySelector(selector) !== null).length;
 
-  return hasJobTitle && formSignals >= 2;
+  const hasApplyButton = Array.from(document.querySelectorAll("button, [type=submit]"))
+    .some(b => /\b(apply|submit)\b/i.test(b.textContent || ""));
+  return (hasJobTitle && formSignals >= 1) || (hasJobTitle && hasApplyButton);
 }
 
 function buildAndSendContext() {
@@ -472,8 +490,8 @@ function buildAndSendContext() {
 
   chrome.runtime.sendMessage<Message>({ type: "PAGE_CONTEXT_UPDATE", payload: context });
 
-  // Notify background that a job page was heuristically detected
-  if (heuristicDetected) {
+  // Notify background that a job page was heuristically or generically detected → opens sidepanel
+  if (heuristicDetected || (mode === "apply" && detectPlatform(url) === "generic")) {
     chrome.runtime.sendMessage<Message>({ type: "JOB_PAGE_DETECTED", context }).catch(() => {});
   }
 

--- a/extension/src/content/floatingPanel.ts
+++ b/extension/src/content/floatingPanel.ts
@@ -73,7 +73,12 @@ const JOB_PAGE_PATTERNS = [
 
 function isJobPage(): boolean {
   const url = window.location.href;
-  return JOB_PAGE_PATTERNS.some((p) => p.test(url));
+  if (JOB_PAGE_PATTERNS.some((p) => p.test(url))) return true;
+  // Heuristic: job-related heading + at least one form element
+  const jobKeywords = /\b(job|position|role|career|engineer|developer|manager|analyst|opening|vacancy|apply|application)\b/i;
+  const hasJobTitle = Array.from(document.querySelectorAll("h1, h2, h3")).some(el => jobKeywords.test(el.textContent || ""));
+  const hasFormSignal = !!document.querySelector('input:not([type=hidden]):not([type=submit]):not([type=button]), textarea, select, [contenteditable="true"]');
+  return hasJobTitle && hasFormSignal;
 }
 
 function extractCompanyAndRoleFromPage(): { company: string; roleTitle: string } {
@@ -128,8 +133,11 @@ function extractCompanyAndRoleFromPage(): { company: string; roleTitle: string }
       ?? docTitle;
   }
   if (!company) {
-    const domain = window.location.hostname.replace(/^www\./, "").split(".")[0] ?? "";
-    company = domain.charAt(0).toUpperCase() + domain.slice(1);
+    const hostname = window.location.hostname.replace(/^www\./, "");
+    const parts = hostname.split(".");
+    const SKIP = new Set(["careers", "jobs", "apply", "hiring", "work", "talent", "recruit"]);
+    const namePart = parts.find(p => p.length > 2 && !SKIP.has(p.toLowerCase())) ?? parts[0] ?? "";
+    company = namePart.split(/[-_]/).map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ").trim();
   }
 
   // Clean trailing noise
@@ -215,6 +223,21 @@ function getFieldLabel(el: HTMLElement): string {
     if (label && label !== el) return label.textContent?.trim() ?? "";
     parent = parent.parentElement;
   }
+  // Check field wrapper with class-based label
+  const wrapper = el.closest("[class*='field'], [class*='Field'], [class*='form-group'], [class*='form-item'], [class*='FormItem'], [class*='FormField']");
+  if (wrapper) {
+    const wrapperLabel = wrapper.querySelector("label, legend, [class*='label'], [class*='Label']");
+    if (wrapperLabel && wrapperLabel !== el) {
+      const text = wrapperLabel.textContent?.trim() ?? "";
+      if (text) return text;
+    }
+  }
+  // Check previous sibling for label text
+  const prev = el.previousElementSibling;
+  if (prev && ["SPAN", "DIV", "LABEL", "P"].includes(prev.tagName)) {
+    const text = prev.textContent?.trim() ?? "";
+    if (text && text.length < 80) return text;
+  }
   return el.getAttribute("name") ?? "";
 }
 
@@ -237,13 +260,14 @@ function classifyField(el: HTMLInputElement | HTMLSelectElement): FieldType {
 function detectFields(): DetectedField[] {
   const inputs = Array.from(
     document.querySelectorAll<HTMLInputElement | HTMLSelectElement>(
-      "input:not([type=hidden]):not([type=submit]):not([type=button]):not([type=checkbox]):not([type=radio]), select"
+      "input:not([type=hidden]):not([type=submit]):not([type=button]), select"
     )
   );
   const fields: DetectedField[] = [];
   for (const el of inputs) {
     const fieldType = classifyField(el as HTMLInputElement);
-    if (fieldType === "unknown" || fieldType === "demographic") continue;
+    if (fieldType === "demographic") continue;
+    if (fieldType === "unknown" && !getFieldLabel(el)) continue;
     // Tag element with a stable data attribute so we can re-find it for fill
     const autoId = `aap_f${fields.length}`;
     el.setAttribute("data-aap-id", autoId);
@@ -264,7 +288,7 @@ function detectQuestions(): DetectedQuestion[] {
   const questions: DetectedQuestion[] = [];
   for (const ta of textareas) {
     const label = getFieldLabel(ta);
-    if (!label || label.length < 10) continue;
+    if (!label || label.length < 3) continue;
     let category: QuestionCategory = "custom";
     for (const { category: cat, patterns } of QUESTION_CATEGORY_PATTERNS) {
       if (patterns.some((p) => p.test(label))) {

--- a/extension/src/sidepanel/hooks/useCoverLetter.ts
+++ b/extension/src/sidepanel/hooks/useCoverLetter.ts
@@ -61,7 +61,6 @@ export function useCoverLetter(context: PageContext): UseCoverLetterResult {
   const [coverLettersSectionOpen, setCoverLettersSectionOpen] = useState(false);
 
   const handleGenerateCoverLetter = async () => {
-    if (!context.company) return;
     setCoverLoading(true);
     setCoverError("");
     setCoverLetter("");
@@ -73,7 +72,7 @@ export function useCoverLetter(context: PageContext): UseCoverLetterResult {
       });
       const candidateName = [profileData.firstName, profileData.lastName].filter(Boolean).join(" ");
       const result = await vaultApi.generateCoverLetter({
-        companyName: context.company,
+        companyName: context.company || "",
         roleTitle: context.roleTitle,
         jdText: context.jdText ?? "",
         tone: coverTone,
@@ -95,7 +94,7 @@ export function useCoverLetter(context: PageContext): UseCoverLetterResult {
   };
 
   const handleSaveCoverLetter = async () => {
-    if (!coverLetter.trim() || !context.company) return;
+    if (!coverLetter.trim()) return;
     setSavingCoverLetter(true);
     try {
       await vaultApi.saveAnswer({

--- a/extension/src/sidepanel/pages/ApplyMode.tsx
+++ b/extension/src/sidepanel/pages/ApplyMode.tsx
@@ -1141,7 +1141,7 @@ export default function ApplyMode({ context }: Props) {
             )}
             <Section label="Detected Form Fields">
               {context.detectedFields.length === 0 ? (
-                <EmptyState message="No fillable fields detected." hint="Fields appear once you navigate to the application form." />
+                <EmptyState message="No fillable fields detected." hint="Navigate directly to the application form page. If fields still don't appear, try clicking a text field on the form to trigger detection." />
               ) : (
                 context.detectedFields.map((f) => {
                   const profileVal = getProfileValue(f.fieldType, profile);
@@ -1208,7 +1208,7 @@ export default function ApplyMode({ context }: Props) {
               </div>
             )}
             {context.openQuestions.length === 0 ? (
-              <EmptyState message="No open questions detected." hint="Questions appear on forms with text areas." />
+              <EmptyState message="No open questions detected." hint="Questions appear when text areas are found on the application form. Try scrolling to or clicking on a text field on the page." />
             ) : (
               context.openQuestions.map((q) => {
                 const drafts = answerDrafts[q.questionId];
@@ -1827,8 +1827,8 @@ export default function ApplyMode({ context }: Props) {
               </select>
               <button
                 onClick={handleGenerateCoverLetter}
-                disabled={coverLoading || !context.company}
-                style={{ ...btnStyle("generate", coverLoading || !context.company), flex: 1, minWidth: 100 }}
+                disabled={coverLoading}
+                style={{ ...btnStyle("generate", coverLoading), flex: 1, minWidth: 100 }}
               >
                 {coverLoading ? "Generating…" : "⚡ Generate"}
               </button>


### PR DESCRIPTION
…etter

Detection:
- detectFields() includes labeled unknown-type fields + checkbox/radio inputs
- detectQuestions() minimum label length 3 chars (was 10 in floatingPanel)
- getFieldLabel() checks wrapper classes + previous sibling for labels
- isJobPage() heuristic fallback for non-ATS domains
- detectJobPageHeuristic() threshold lowered to 1 form signal (was 2)

Auto-open + sidepanel:
- worker.ts JOB_PAGE_DETECTED now relays PAGE_CONTEXT_UPDATE to sidepanel
- worker.ts CAREER_URL_PATTERNS expanded (paylocity, eightfold, breezy, etc.)
- detector.ts sends JOB_PAGE_DETECTED for all generic career pages
- extractCompanyFromUrl() skips careers/jobs prefixes, reads real domain

manifest.json:
- floatingPanel.js injected on careers.*.* / jobs.*.* / apply.*.* patterns
- Added 7 new ATS domains (recruitingbypaycor, paylocity, eightfold, etc.)

ApplyMode + Cover Letter:
- Generate button no longer disabled when context.company is empty
- useCoverLetter: removed !context.company guard from handleGenerateCoverLetter
- Fields empty state: actionable hint
- Q&A empty state: actionable hint