### PR TITLE
feat(billing): Stripe data layer — Phase A (#93)

### DIFF
--- a/backend/alembic/versions/b6d2e4f8a1c3_add_subscription_and_usage_tracking.py
+++ b/backend/alembic/versions/b6d2e4f8a1c3_add_subscription_and_usage_tracking.py
@@ -1,0 +1,137 @@
+"""add subscription and usage tracking
+
+Revision ID: b6d2e4f8a1c3
+Revises: 45ca64ce5f2e
+Create Date: 2026-03-30 00:00:00.000000
+
+Phase A of Stripe billing integration:
+- plan_enum / subscription_status_enum Postgres enums
+- subscriptions table (one-to-one with users)
+- usage_records table (one-per-billing-period per user)
+- stripe_customer_id column on users
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "b6d2e4f8a1c3"
+down_revision: str | None = "45ca64ce5f2e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+plan_enum = postgresql.ENUM("free", "pro", "team", name="plan_enum", create_type=False)
+subscription_status_enum = postgresql.ENUM(
+    "active",
+    "trialing",
+    "past_due",
+    "canceled",
+    "unpaid",
+    name="subscription_status_enum",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    # --- enums ---
+    sa.Enum("free", "pro", "team", name="plan_enum").create(op.get_bind(), checkfirst=True)
+    sa.Enum(
+        "active",
+        "trialing",
+        "past_due",
+        "canceled",
+        "unpaid",
+        name="subscription_status_enum",
+    ).create(op.get_bind(), checkfirst=True)
+
+    # --- subscriptions ---
+    op.create_table(
+        "subscriptions",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("stripe_customer_id", sa.String(255), nullable=True),
+        sa.Column("stripe_subscription_id", sa.String(255), nullable=True),
+        sa.Column("plan", plan_enum, nullable=False, server_default="free"),
+        sa.Column("status", subscription_status_enum, nullable=False, server_default="active"),
+        sa.Column("current_period_start", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("current_period_end", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "cancel_at_period_end", sa.Boolean(), nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("user_id", name="uq_subscriptions_user_id"),
+    )
+    op.create_index("ix_subscriptions_user_id", "subscriptions", ["user_id"])
+    op.create_index("ix_subscriptions_stripe_customer_id", "subscriptions", ["stripe_customer_id"])
+    op.create_index(
+        "ix_subscriptions_stripe_subscription_id", "subscriptions", ["stripe_subscription_id"]
+    )
+
+    # --- usage_records ---
+    op.create_table(
+        "usage_records",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("period_start", sa.Date(), nullable=False),
+        sa.Column("resume_tailors_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("qa_drafts_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("cover_letters_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("user_id", "period_start", name="uq_usage_user_period"),
+    )
+    op.create_index("ix_usage_records_user_id", "usage_records", ["user_id"])
+
+    # --- users.stripe_customer_id ---
+    op.add_column("users", sa.Column("stripe_customer_id", sa.String(255), nullable=True))
+    op.create_index("ix_users_stripe_customer_id", "users", ["stripe_customer_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_stripe_customer_id", table_name="users")
+    op.drop_column("users", "stripe_customer_id")
+
+    op.drop_index("ix_usage_records_user_id", table_name="usage_records")
+    op.drop_table("usage_records")
+
+    op.drop_index("ix_subscriptions_stripe_subscription_id", table_name="subscriptions")
+    op.drop_index("ix_subscriptions_stripe_customer_id", table_name="subscriptions")
+    op.drop_index("ix_subscriptions_user_id", table_name="subscriptions")
+    op.drop_table("subscriptions")
+
+    sa.Enum(name="subscription_status_enum").drop(op.get_bind(), checkfirst=True)
+    sa.Enum(name="plan_enum").drop(op.get_bind(), checkfirst=True)

--- a/backend/app/core/billing_config.py
+++ b/backend/app/core/billing_config.py
@@ -1,0 +1,34 @@
+"""
+Billing tier limits for Stripe subscription enforcement.
+
+None means unlimited. Enforced at the service layer via get_limit().
+"""
+
+FREE_LIMITS: dict[str, int | None] = {
+    "resume_tailors": 5,
+    "qa_drafts": 20,
+    "cover_letters": 3,
+}
+
+PRO_LIMITS: dict[str, int | None] = {
+    "resume_tailors": None,
+    "qa_drafts": None,
+    "cover_letters": None,
+}
+
+TEAM_LIMITS: dict[str, int | None] = {
+    "resume_tailors": None,
+    "qa_drafts": None,
+    "cover_letters": None,
+}
+
+PLAN_LIMITS = {
+    "free": FREE_LIMITS,
+    "pro": PRO_LIMITS,
+    "team": TEAM_LIMITS,
+}
+
+
+def get_limit(plan: str, feature: str) -> int | None:
+    """Return the limit for a feature under a given plan. None = unlimited."""
+    return PLAN_LIMITS.get(plan, FREE_LIMITS).get(feature)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,8 @@ from app.models.audit_log import AuditLog
 from app.models.base import Base, TimestampMixin, async_session_factory, engine
 from app.models.document_chunk import DocumentChunk
 from app.models.resume import ApplicationAnswer, Resume, ResumeUsage
+from app.models.subscription import Plan, Subscription, SubscriptionStatus
+from app.models.usage_record import UsageRecord
 from app.models.user import User
 from app.models.user_provider_config import UserProviderConfig
 from app.models.work_history import WorkHistoryEntry
@@ -21,4 +23,8 @@ __all__ = [
     "ApplicationAnswer",
     "UserProviderConfig",
     "WorkHistoryEntry",
+    "Subscription",
+    "Plan",
+    "SubscriptionStatus",
+    "UsageRecord",
 ]

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -1,0 +1,68 @@
+"""
+Subscription model — tracks Stripe billing state per user.
+"""
+
+import uuid
+from datetime import datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class Plan(StrEnum):
+    free = "free"
+    pro = "pro"
+    team = "team"
+
+
+class SubscriptionStatus(StrEnum):
+    active = "active"
+    trialing = "trialing"
+    past_due = "past_due"
+    canceled = "canceled"
+    unpaid = "unpaid"
+
+
+class Subscription(Base, TimestampMixin):
+    __tablename__ = "subscriptions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    stripe_customer_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
+    stripe_subscription_id: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, index=True
+    )
+    plan: Mapped[Plan] = mapped_column(
+        Enum(Plan, name="plan_enum", native_enum=True),
+        nullable=False,
+        default=Plan.free,
+    )
+    status: Mapped[SubscriptionStatus] = mapped_column(
+        Enum(SubscriptionStatus, name="subscription_status_enum", native_enum=True),
+        nullable=False,
+        default=SubscriptionStatus.active,
+    )
+    current_period_start: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    current_period_end: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cancel_at_period_end: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Relationships
+    user: Mapped["User"] = relationship(back_populates="subscription")

--- a/backend/app/models/usage_record.py
+++ b/backend/app/models/usage_record.py
@@ -1,0 +1,37 @@
+"""
+UsageRecord model — tracks monthly feature usage per user for plan enforcement.
+"""
+
+import uuid
+from datetime import date
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Date, ForeignKey, Integer, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class UsageRecord(Base, TimestampMixin):
+    __tablename__ = "usage_records"
+
+    __table_args__ = (UniqueConstraint("user_id", "period_start", name="uq_usage_user_period"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    period_start: Mapped[date] = mapped_column(Date, nullable=False)
+    resume_tailors_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    qa_drafts_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cover_letters_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    # Relationships
+    user: Mapped["User"] = relationship(back_populates="usage_records")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from app.models.application import Application
+    from app.models.subscription import Subscription
+    from app.models.usage_record import UsageRecord
     from app.models.user_provider_config import UserProviderConfig
 
 
@@ -48,8 +50,17 @@ class User(Base, TimestampMixin):
     salary: Mapped[str | None] = mapped_column(String(100))
     sponsorship: Mapped[str | None] = mapped_column(String(100))
 
+    # Billing
+    stripe_customer_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
+
     # Relationships
     applications: Mapped[list["Application"]] = relationship(back_populates="user")
     provider_configs: Mapped[list["UserProviderConfig"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    subscription: Mapped["Subscription | None"] = relationship(
+        back_populates="user", uselist=False, cascade="all, delete-orphan"
+    )
+    usage_records: Mapped[list["UsageRecord"]] = relationship(
         back_populates="user", cascade="all, delete-orphan"
     )


### PR DESCRIPTION
## Summary

Phase A of two for issue #93 — adds the Stripe billing data layer. Pure data work, no runtime endpoints (those land in Phase B / PR #2, stacked on this).

- `Subscription` model: plan_enum (free/pro/team), subscription_status_enum, stripe_customer_id/subscription_id, period dates, cancel_at_period_end
- `UsageRecord` model: per-user per-period counters for resume_tailors, qa_drafts, cover_letters (unique on user_id + period_start)
- `User.stripe_customer_id`: nullable indexed column + relationships to Subscription and UsageRecord
- `app/core/billing_config.py`: FREE/PRO/TEAM limits dicts + get_limit() helper
- Migration `b6d2e4f8a1c3`: creates enums + tables, chains off current `main` head (`45ca64ce5f2e`) so no merge-heads needed

## Test plan

- [x] Static-verify alembic chain has a single head after this migration
- [x] All model imports load (`from app.models import Subscription, UsageRecord`)
- [x] pre-commit hook (ruff + black + mypy) passes
- [ ] CI runs alembic upgrade head on the test DB without error
- [ ] Phase B (PR #2) lands on top — checkout, portal, webhook endpoints

## Notes for review

The Phase A commit was originally drafted on a now-stale Claude branch with `down_revision = "f3a7b1c2d4e5"` (the grandparent of current main's head). I re-parented it to `45ca64ce5f2e` (current main HEAD) so the migration chain stays linear — no `alembic merge heads` migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)