### PR TITLE
feat(#107): LLMGateway Phase 2 — Redis CB, metrics, structured errors, service migration

### DIFF
--- a/backend/app/routers/vault/answers.py
+++ b/backend/app/routers/vault/answers.py
@@ -19,13 +19,7 @@ from app.dependencies import get_current_user, get_db
 from app.models.resume import ApplicationAnswer
 from app.models.user import User
 from app.models.work_history import WorkHistoryEntry
-from app.services.llm_gateway import (
-    _call_anthropic,
-    _call_gemini,
-    _call_groq,
-    _call_kimi,
-    _call_openai,
-)
+from app.services.llm_gateway import LLMGateway
 from app.services.rag_service import get_rag_context_for_query
 from app.services.resume_generator import (
     _PROVIDER_RANK,
@@ -213,28 +207,23 @@ TEXT TO SHORTEN:
     provider_used = "truncation"
 
     if providers_list:
+        # Issue #107 — uniform dispatch via LLMGateway (per-provider Redis
+        # circuit breaker + metrics). Keep the priority-rank ordering so
+        # we still try the user's preferred provider first.
         sorted_p = sorted(providers_list, key=lambda p: _PROVIDER_RANK.get(p.get("name", ""), 50))
+        gateway = LLMGateway()
         for p in sorted_p:
             name = p.get("name", "")
             api_key = p.get("api_key", "")
-            model = p.get("model", "")
+            if not name or not api_key:
+                continue
             try:
-                if name == "anthropic" and api_key:
-                    raw = await _call_anthropic(system_prompt, user_prompt, api_key)
-                elif name == "openai" and api_key:
-                    raw = await _call_openai(system_prompt, user_prompt, api_key)
-                elif name == "gemini" and api_key:
-                    raw = await _call_gemini(
-                        system_prompt, user_prompt, api_key, model or "gemini-1.5-flash"
-                    )
-                elif name == "groq" and api_key:
-                    raw = await _call_groq(
-                        system_prompt, user_prompt, api_key, model or "llama-3.3-70b-versatile"
-                    )
-                elif name == "kimi" and api_key:
-                    raw = await _call_kimi(system_prompt, user_prompt, api_key)
-                else:
-                    continue
+                raw, _provider_used = await gateway.generate(
+                    system_prompt=system_prompt,
+                    user_prompt=user_prompt,
+                    provider=name,
+                    api_key=api_key,
+                )
                 if raw and len(raw.strip()) > 20:
                     trimmed = raw.strip()[:max_chars]
                     provider_used = name

--- a/backend/app/routers/vault/interview.py
+++ b/backend/app/routers/vault/interview.py
@@ -12,13 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_current_user, get_db
 from app.models.user import User
 from app.models.work_history import WorkHistoryEntry
-from app.services.llm_gateway import (
-    _call_anthropic,
-    _call_gemini,
-    _call_groq,
-    _call_kimi,
-    _call_openai,
-)
+from app.services.llm_gateway import LLMGateway
 
 router = APIRouter()
 
@@ -95,26 +89,22 @@ Generate 10 interview questions + suggested answers as described."""
     questions: list[dict] = []
 
     if providers_list:
+        # Issue #107 — route every provider through LLMGateway (uniform
+        # circuit-breaker, metrics, and cascade behaviour).
+        gateway = LLMGateway()
         for prov in providers_list:
             name = prov.get("name", "")
             api_key = prov.get("api_key", "")
-            model = prov.get("model", "")
+            if not name or not api_key:
+                continue
             try:
-                if name == "anthropic":
-                    raw = await _call_anthropic(_INTERVIEW_SYSTEM, user_prompt, api_key)
-                elif name == "openai":
-                    raw = await _call_openai(_INTERVIEW_SYSTEM, user_prompt, api_key)
-                elif name == "groq":
-                    raw = await _call_groq(
-                        _INTERVIEW_SYSTEM, user_prompt, api_key, model or "llama-3.3-70b-versatile"
-                    )
-                elif name == "gemini":
-                    raw = await _call_gemini(
-                        _INTERVIEW_SYSTEM, user_prompt, api_key, model or "gemini-1.5-flash"
-                    )
-                elif name == "kimi":
-                    raw = await _call_kimi(_INTERVIEW_SYSTEM, user_prompt, api_key)
-                else:
+                raw, _provider_used = await gateway.generate(
+                    system_prompt=_INTERVIEW_SYSTEM,
+                    user_prompt=user_prompt,
+                    provider=name,
+                    api_key=api_key,
+                )
+                if not raw:
                     continue
                 parsed = _json.loads(raw.strip())
                 if isinstance(parsed, list) and len(parsed) > 0:

--- a/backend/app/services/email_classifier_service.py
+++ b/backend/app/services/email_classifier_service.py
@@ -214,6 +214,15 @@ async def classify_email_status(
     )
 
     # Step 3: try LLM
+    #
+    # NOTE (Issue #107 / Phase 2): this call site intentionally keeps the
+    # ``PROVIDERS[provider].complete()`` abstraction rather than going
+    # through ``LLMGateway.generate()``. The provider classes already wrap
+    # their HTTP calls in the in-process ``llm_circuit`` decorator, and
+    # routing through the gateway would require updating every existing
+    # test that patches ``PROVIDERS`` to instead patch the gateway's
+    # internal ``_call_*`` helpers — far more invasive than the value
+    # added here. Tracked as a follow-up for a dedicated migration PR.
     llm_provider = PROVIDERS.get(provider, PROVIDERS.get("fallback"))
     if llm_provider is None:
         logger.warning(f"Unknown LLM provider '{provider}' — using keyword fallback")

--- a/backend/app/services/llm_circuit_redis.py
+++ b/backend/app/services/llm_circuit_redis.py
@@ -1,0 +1,160 @@
+"""
+Redis-backed circuit breaker for LLM provider dispatch.
+
+Issue #107 — Phase 2. Per-provider circuit state lives in Redis under
+``llm:circuit:{provider}`` keys with a 60-second TTL. When a provider
+records ``_FAILURE_THRESHOLD`` consecutive failures inside the rolling
+60-second window, the circuit opens and ``LLMGateway`` skips it until
+the key expires.
+
+Design notes
+------------
+* The breaker is *advisory*. If Redis is unavailable we log a warning
+  once per failure and proceed without circuit-breaking — the request
+  must never fail because of a missing observability dependency.
+* State keys carry their own TTL so we never need a separate
+  half-open timer: a single ``GET`` is all the gateway needs.
+* Failure counters live under ``llm:circuit:{provider}:fails`` with the
+  same TTL; reaching the threshold flips the circuit-open key on.
+* The module is intentionally light on assumptions about how Redis is
+  managed — it accepts an optional ``redis_url`` so tests can wire a
+  fake client, but defaults to ``settings.REDIS_URL`` so production
+  callers don't need to plumb the URL through.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import Any
+
+from loguru import logger
+
+from app.config import settings
+
+_FAILURE_THRESHOLD = 3
+_WINDOW_SECONDS = 60
+
+_CIRCUIT_KEY = "llm:circuit:{provider}"
+_FAILS_KEY = "llm:circuit:{provider}:fails"
+
+
+def _circuit_key(provider: str) -> str:
+    return _CIRCUIT_KEY.format(provider=provider)
+
+
+def _fails_key(provider: str) -> str:
+    return _FAILS_KEY.format(provider=provider)
+
+
+async def _get_client(redis_url: str | None = None) -> Any | None:
+    """Build a Redis client or return ``None`` if construction fails.
+
+    A returned ``None`` signals "no Redis available" and the breaker
+    falls back to a permissive mode (every provider is considered
+    closed). Callers must not raise on a ``None`` client.
+    """
+    try:
+        # Imported lazily so test environments without redis still load.
+        from redis.asyncio import Redis  # noqa: WPS433
+
+        url = redis_url or settings.REDIS_URL
+        return Redis.from_url(
+            url,
+            decode_responses=True,
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
+    except Exception as exc:  # pragma: no cover - import / config failures
+        logger.warning(f"llm.circuit: redis client unavailable ({exc}); skipping breaker")
+        return None
+
+
+async def is_open(provider: str, client: Any | None = None) -> bool:
+    """Return True iff ``provider`` is currently circuit-open.
+
+    A Redis failure is treated as "closed" so the request still
+    attempts the provider — graceful degradation per spec.
+    """
+    owns_client = False
+    if client is None:
+        client = await _get_client()
+        owns_client = True
+    if client is None:
+        return False
+
+    try:
+        flag = await client.get(_circuit_key(provider))
+        return flag is not None
+    except Exception as exc:
+        logger.warning(f"llm.circuit: GET failed for '{provider}' ({exc}); treating as closed")
+        return False
+    finally:
+        if owns_client:
+            with contextlib.suppress(Exception):  # pragma: no cover - defensive
+                await client.aclose()
+
+
+async def record_success(provider: str, client: Any | None = None) -> None:
+    """Reset the failure counter for ``provider``.
+
+    Closing the circuit is implicit: the open flag has a 60-second
+    TTL and expires on its own, so we only need to clear the fail
+    counter to prevent flap.
+    """
+    owns_client = False
+    if client is None:
+        client = await _get_client()
+        owns_client = True
+    if client is None:
+        return
+
+    try:
+        await client.delete(_fails_key(provider))
+    except Exception as exc:
+        logger.warning(f"llm.circuit: DEL fails failed for '{provider}' ({exc})")
+    finally:
+        if owns_client:
+            with contextlib.suppress(Exception):  # pragma: no cover - defensive
+                await client.aclose()
+
+
+async def record_failure(provider: str, client: Any | None = None) -> bool:
+    """Increment the failure counter; return True if circuit just opened.
+
+    The counter shares the same 60-second TTL as the open flag — if a
+    provider has 3 failures within 60s the circuit trips; otherwise
+    older failures expire and never accumulate.
+    """
+    owns_client = False
+    if client is None:
+        client = await _get_client()
+        owns_client = True
+    if client is None:
+        return False
+
+    just_opened = False
+    try:
+        fails_key = _fails_key(provider)
+        count = await client.incr(fails_key)
+        # Ensure the counter expires so failures more than ``_WINDOW_SECONDS``
+        # old roll out of the sliding window even if no new failures arrive.
+        await client.expire(fails_key, _WINDOW_SECONDS)
+        if int(count) >= _FAILURE_THRESHOLD:
+            await client.set(_circuit_key(provider), "1", ex=_WINDOW_SECONDS)
+            just_opened = True
+    except Exception as exc:
+        logger.warning(f"llm.circuit: INCR failed for '{provider}' ({exc}); skipping breaker")
+    finally:
+        if owns_client:
+            with contextlib.suppress(Exception):  # pragma: no cover - defensive
+                await client.aclose()
+    return just_opened
+
+
+__all__ = [
+    "is_open",
+    "record_failure",
+    "record_success",
+    "_FAILURE_THRESHOLD",
+    "_WINDOW_SECONDS",
+]

--- a/backend/app/services/llm_gateway.py
+++ b/backend/app/services/llm_gateway.py
@@ -145,14 +145,20 @@ except ImportError:  # pragma: no cover - prometheus_client missing
 def _emit_metric(provider: str, status: str, duration_ms: float) -> None:
     """Record a request metric for ``provider`` (``success`` or ``failure``).
 
-    Always emits a structured loguru info event so log-based dashboards
+    Always emits a key=value loguru info event so log-based dashboards
     keep working when prometheus_client is unavailable.
+
+    Issue #191 — Loguru does not render keyword arguments into its default
+    sink: ``logger.info("llm.request", provider=...)`` would emit only
+    ``llm.request`` and stash the kwargs in ``record["extra"]`` where no
+    aggregator picks them up. We use a positional format string so the
+    label/value pairs are part of the rendered line.
     """
     logger.info(
-        "llm.request",
-        provider=provider,
-        duration_ms=round(duration_ms, 2),
-        status=status,
+        "llm.request provider={} duration_ms={} status={}",
+        provider,
+        round(duration_ms, 2),
+        status,
     )
     if _HAS_PROMETHEUS:
         try:

--- a/backend/app/services/llm_gateway.py
+++ b/backend/app/services/llm_gateway.py
@@ -80,6 +80,7 @@ def _scrub(text: object) -> str:
         s = pattern.sub("[REDACTED]", s)
     return s
 
+
 # -- Prometheus metrics (optional) --
 # Use ``prometheus_client`` if available — it ships as a transitive dep of
 # ``prometheus-fastapi-instrumentator``. We fall back to structured loguru
@@ -110,9 +111,7 @@ try:  # pragma: no cover - import guard
                 raise
             return existing  # type: ignore[return-value]
 
-    def _get_or_create_counter(
-        name: str, doc: str, labelnames: tuple[str, ...]
-    ) -> Counter:
+    def _get_or_create_counter(name: str, doc: str, labelnames: tuple[str, ...]) -> Counter:
         try:
             return Counter(name, doc, labelnames=labelnames)
         except ValueError:
@@ -1112,6 +1111,23 @@ async def tailor_resume(
         bullet_count=resume_ast.bullet_count,
     )
 
+    # ── Redis circuit breaker check (#189) ─────────────────
+    # The Redis breaker only protected ``LLMGateway.generate``'s cascade
+    # before this fix. ``tailor_resume`` calls ``provider.complete()``
+    # directly via the PROVIDERS registry, so the highest-volume caller
+    # bypassed the new breaker entirely. Gate the call here so a tripped
+    # breaker short-circuits to the keyword fallback path.
+    if provider_name not in ("fallback", "") and await llm_circuit_redis.is_open(provider_name):
+        logger.warning(
+            "tailor_resume: provider '{}' circuit OPEN — using keyword fallback",
+            provider_name,
+        )
+        return (
+            [b.text for b in resume_ast.bullets],
+            True,
+            "LLM service temporarily unavailable (circuit open). Showing original.",
+        )
+
     # ── Call the LLM ──────────────────────────────────────
     try:
         raw_response = await provider.complete(SYSTEM_PROMPT, user_prompt, api_key)
@@ -1124,6 +1140,12 @@ async def tailor_resume(
                 "LLM unavailable. Showing original bullets with keyword relevance scores.",
             )
 
+        # Record success against the Redis breaker so a streak of
+        # transient failures doesn't accidentally keep the circuit closed
+        # by an unrelated record_failure from another caller (#189).
+        if provider_name not in ("fallback", ""):
+            await llm_circuit_redis.record_success(provider_name)
+
         # Parse the response into individual bullets
         rewritten_bullets = _parse_llm_response(raw_response, resume_ast.bullet_count)
 
@@ -1135,6 +1157,8 @@ async def tailor_resume(
         return rewritten_bullets, False, summary
 
     except CircuitOpenError as e:
+        # The in-process @llm_circuit decorator on provider.complete() can
+        # trip independently of the Redis breaker. Preserve legacy behaviour.
         logger.warning(f"Circuit open for {provider_name}: {_scrub(e)}")
         return (
             [b.text for b in resume_ast.bullets],
@@ -1143,6 +1167,8 @@ async def tailor_resume(
         )
 
     except InvalidAPIKeyError:
+        # Auth failures don't indicate provider health — don't record as
+        # a circuit breaker failure (#189).
         logger.warning(f"Invalid API key for {provider_name}")
         return (
             [b.text for b in resume_ast.bullets],
@@ -1151,6 +1177,9 @@ async def tailor_resume(
         )
 
     except RateLimitError:
+        # Rate-limit IS a provider health signal — increment the breaker.
+        if provider_name not in ("fallback", ""):
+            await llm_circuit_redis.record_failure(provider_name)
         logger.warning(f"Rate limited by {provider_name}")
         return (
             [b.text for b in resume_ast.bullets],
@@ -1159,6 +1188,10 @@ async def tailor_resume(
         )
 
     except Exception as e:
+        # Any other failure counts as a provider failure for the Redis
+        # breaker — three of these in a 60s window open the circuit.
+        if provider_name not in ("fallback", ""):
+            await llm_circuit_redis.record_failure(provider_name)
         # Issue #190 — never dump raw exception text (or its traceback) when
         # the upstream body may contain echoed API keys. Strip secrets first
         # and drop ``exc_info`` so loguru's diagnose-formatter doesn't expand

--- a/backend/app/services/llm_gateway.py
+++ b/backend/app/services/llm_gateway.py
@@ -796,6 +796,7 @@ class LLMGateway:
         provider: str,
         api_key: str = "",
         ollama_model: str = "llama3.1:8b",
+        model: str | None = None,
     ) -> tuple[str, str]:
         """
         Dispatch a completion request through the provider cascade.
@@ -814,6 +815,11 @@ class LLMGateway:
             provider will be skipped and the cascade starts at Ollama.
         ollama_model:
             Ollama model tag (default "llama3.1:8b").
+        model:
+            Optional per-provider model id override. When set, ``gemini``,
+            ``groq``, and ``perplexity`` use this model id instead of their
+            built-in defaults (#188). Ignored for providers that don't
+            accept a runtime model override (anthropic, openai, kimi).
 
         Returns
         -------
@@ -838,14 +844,42 @@ class LLMGateway:
         elif provider == "openai" and api_key:
             cascade.append(("openai", lambda: _call_openai(system_prompt, user_prompt, api_key)))
         elif provider == "groq" and api_key:
-            cascade.append(("groq", lambda: _call_groq(system_prompt, user_prompt, api_key)))
+            cascade.append(
+                (
+                    "groq",
+                    lambda: _call_groq(
+                        system_prompt,
+                        user_prompt,
+                        api_key,
+                        model or "llama-3.3-70b-versatile",
+                    ),
+                )
+            )
         elif provider == "kimi" and api_key:
             cascade.append(("kimi", lambda: _call_kimi(system_prompt, user_prompt, api_key)))
         elif provider == "gemini" and api_key:
-            cascade.append(("gemini", lambda: _call_gemini(system_prompt, user_prompt, api_key)))
+            cascade.append(
+                (
+                    "gemini",
+                    lambda: _call_gemini(
+                        system_prompt,
+                        user_prompt,
+                        api_key,
+                        model or "gemini-1.5-flash",
+                    ),
+                )
+            )
         elif provider == "perplexity" and api_key:
             cascade.append(
-                ("perplexity", lambda: _call_perplexity(system_prompt, user_prompt, api_key))
+                (
+                    "perplexity",
+                    lambda: _call_perplexity(
+                        system_prompt,
+                        user_prompt,
+                        api_key,
+                        model or "sonar",
+                    ),
+                )
             )
         elif provider == "ollama":
             # Ollama needs no key; add it as primary and skip the second append below

--- a/backend/app/services/llm_gateway.py
+++ b/backend/app/services/llm_gateway.py
@@ -797,6 +797,7 @@ class LLMGateway:
         api_key: str = "",
         ollama_model: str = "llama3.1:8b",
         model: str | None = None,
+        skip_fallback: bool = False,
     ) -> tuple[str, str]:
         """
         Dispatch a completion request through the provider cascade.
@@ -820,6 +821,14 @@ class LLMGateway:
             ``groq``, and ``perplexity`` use this model id instead of their
             built-in defaults (#188). Ignored for providers that don't
             accept a runtime model override (anthropic, openai, kimi).
+        skip_fallback:
+            When True, do not append Ollama as a secondary attempt
+            (#186). Callers that supply their own outer fallback loop
+            should set this to avoid double-fallback / provider
+            misattribution (e.g. a cloud provider fails, the gateway
+            silently tries Ollama for up to 180s, and the outer loop
+            then records the cloud provider's name as the one that
+            answered).
 
         Returns
         -------
@@ -888,7 +897,11 @@ class LLMGateway:
             )
 
         # Always append Ollama as local fallback unless it is already primary
-        if provider != "ollama":
+        # or the caller opted out via ``skip_fallback`` (#186). Callers like
+        # ``_dispatch_provider_entry`` own their own outer-loop fallback and
+        # don't want the gateway to silently retry a 180s Ollama call after
+        # a cloud provider error.
+        if provider != "ollama" and not skip_fallback:
             cascade.append(
                 ("ollama", lambda: _call_ollama(system_prompt, user_prompt, ollama_model))
             )

--- a/backend/app/services/llm_gateway.py
+++ b/backend/app/services/llm_gateway.py
@@ -45,21 +45,59 @@ from app.utils.encryption import decrypt_value
 # Use ``prometheus_client`` if available — it ships as a transitive dep of
 # ``prometheus-fastapi-instrumentator``. We fall back to structured loguru
 # logs when the import fails so the gateway works in minimal environments.
+#
+# Issue #185: collectors must survive ``importlib.reload(llm_gateway)`` and
+# uvicorn ``--reload``. The previous bare ``except Exception`` caught
+# ``Duplicated timeseries`` and silently disabled metrics for the rest of
+# the process. We now scope the exception to ``ValueError`` (the only one
+# Prometheus raises on duplicate registration) and recover the existing
+# collector from the default ``REGISTRY``.
 try:  # pragma: no cover - import guard
-    from prometheus_client import Counter, Histogram
+    from prometheus_client import REGISTRY, Counter, Histogram
 
-    _llm_request_duration_seconds = Histogram(
+    # Buckets covering LLM latency: sub-second snappy responses through
+    # the 180s Ollama timeout. ``+Inf`` is appended automatically by
+    # prometheus_client but we include it explicitly for clarity.
+    _LLM_LATENCY_BUCKETS = (0.5, 1, 2, 5, 10, 20, 30, 60, 120, 180, float("inf"))
+
+    def _get_or_create_histogram(
+        name: str, doc: str, labelnames: tuple[str, ...], buckets: tuple[float, ...]
+    ) -> Histogram:
+        try:
+            return Histogram(name, doc, labelnames=labelnames, buckets=buckets)
+        except ValueError:
+            existing = REGISTRY._names_to_collectors.get(name)  # type: ignore[attr-defined]
+            if existing is None:  # pragma: no cover - defensive
+                raise
+            return existing  # type: ignore[return-value]
+
+    def _get_or_create_counter(
+        name: str, doc: str, labelnames: tuple[str, ...]
+    ) -> Counter:
+        try:
+            return Counter(name, doc, labelnames=labelnames)
+        except ValueError:
+            existing = REGISTRY._names_to_collectors.get(name)  # type: ignore[attr-defined]
+            if existing is None:  # pragma: no cover - defensive
+                # prometheus_client stores Counters under "<name>_total".
+                existing = REGISTRY._names_to_collectors.get(f"{name}_total")  # type: ignore[attr-defined]
+            if existing is None:  # pragma: no cover - defensive
+                raise
+            return existing  # type: ignore[return-value]
+
+    _llm_request_duration_seconds = _get_or_create_histogram(
         "llm_request_duration_seconds",
         "Duration of LLM provider requests in seconds.",
-        labelnames=("provider",),
+        ("provider",),
+        _LLM_LATENCY_BUCKETS,
     )
-    _llm_request_total = Counter(
+    _llm_request_total = _get_or_create_counter(
         "llm_request_total",
         "Total LLM provider requests.",
-        labelnames=("provider", "status"),
+        ("provider", "status"),
     )
     _HAS_PROMETHEUS = True
-except Exception:  # pragma: no cover - prometheus_client missing
+except ImportError:  # pragma: no cover - prometheus_client missing
     _llm_request_duration_seconds = None  # type: ignore[assignment]
     _llm_request_total = None  # type: ignore[assignment]
     _HAS_PROMETHEUS = False

--- a/backend/app/services/llm_gateway.py
+++ b/backend/app/services/llm_gateway.py
@@ -41,6 +41,45 @@ from app.services import llm_circuit_redis
 from app.services.resume_parser import ResumeAST
 from app.utils.encryption import decrypt_value
 
+# -- Secret scrubbing --
+# Issue #190 — exception bodies from Gemini / Perplexity / Groq sometimes
+# echo the API key (query string, Authorization header, x-api-key). We
+# never want those reaching logs or LLMGenerationError.__repr__. The
+# scrubber runs over every interpolation point that mixes user input or
+# upstream-error text into a log line.
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Anthropic
+    re.compile(r"sk-ant-[A-Za-z0-9_\-]+"),
+    # OpenAI / generic sk-* tokens (length >= 20)
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),
+    # Groq
+    re.compile(r"gsk_[A-Za-z0-9]+"),
+    # Perplexity
+    re.compile(r"pplx-[A-Za-z0-9]+"),
+    # Google AI Studio / Gemini
+    re.compile(r"AIza[0-9A-Za-z_\-]{35}"),
+    # Bearer tokens (Authorization header)
+    re.compile(r"Bearer\s+[A-Za-z0-9._~+/\-]+=*", re.IGNORECASE),
+    # x-api-key header value
+    re.compile(r"x-api-key\s*[:=]\s*\S+", re.IGNORECASE),
+    # ?key=... / &api_key=... query params
+    re.compile(r"[?&](?:key|api_key)=[^&\s]+", re.IGNORECASE),
+)
+
+
+def _scrub(text: object) -> str:
+    """Redact known secret-shaped substrings from ``text``.
+
+    Always returns a string. Used at every site that interpolates an
+    upstream exception or arbitrary string into a log line / error
+    message so a leaked API key in a 4xx body can't escape the gateway.
+    """
+    s = str(text)
+    for pattern in _SECRET_PATTERNS:
+        s = pattern.sub("[REDACTED]", s)
+    return s
+
 # -- Prometheus metrics (optional) --
 # Use ``prometheus_client`` if available — it ships as a transitive dep of
 # ``prometheus-fastapi-instrumentator``. We fall back to structured loguru
@@ -705,9 +744,13 @@ class LLMGenerationError(Exception):
         self.cause = cause
 
     def __repr__(self) -> str:
+        # Issue #190 — ``cause`` is an upstream exception whose ``repr``
+        # may contain echoed API keys (e.g. Gemini's ``?key=...`` URL).
+        # Scrub before exposing.
+        cause_repr = "None" if self.cause is None else _scrub(repr(self.cause))
         return (
             f"LLMGenerationError(provider={self.provider!r}, "
-            f"attempt_number={self.attempt_number}, cause={self.cause!r})"
+            f"attempt_number={self.attempt_number}, cause={cause_repr})"
         )
 
 
@@ -989,8 +1032,12 @@ class LLMGateway:
             except Exception as exc:
                 duration_ms = (time.monotonic() - start) * 1000.0
                 _emit_metric(name, "failure", duration_ms)
+                # Issue #190 — upstream exception bodies sometimes echo the
+                # API key (Gemini ?key=, Perplexity x-api-key, etc.) so we
+                # scrub before interpolating into the error message and log.
+                safe_exc_text = _scrub(exc)
                 err = LLMGenerationError(
-                    f"Provider '{name}' raised: {exc}",
+                    f"Provider '{name}' raised: {safe_exc_text}",
                     provider=name,
                     attempt_number=attempt_number,
                     cause=exc,
@@ -1000,7 +1047,7 @@ class LLMGateway:
                     name,
                     attempt_number,
                     duration_ms,
-                    exc,
+                    safe_exc_text,
                 )
                 await llm_circuit_redis.record_failure(name)
 
@@ -1041,7 +1088,9 @@ async def tailor_resume(
         try:
             api_key = decrypt_value(encrypted_api_key)
         except Exception as e:
-            logger.error(f"Failed to decrypt API key: {e}")
+            # Issue #190 — defensive scrub; the encrypted value should never
+            # land in the exception text but better safe than sorry.
+            logger.error(f"Failed to decrypt API key: {_scrub(e)}")
             provider = PROVIDERS["fallback"]
 
     # ── Validate key format ───────────────────────────────
@@ -1080,7 +1129,7 @@ async def tailor_resume(
         return rewritten_bullets, False, summary
 
     except CircuitOpenError as e:
-        logger.warning(f"Circuit open for {provider_name}: {e}")
+        logger.warning(f"Circuit open for {provider_name}: {_scrub(e)}")
         return (
             [b.text for b in resume_ast.bullets],
             True,
@@ -1104,11 +1153,16 @@ async def tailor_resume(
         )
 
     except Exception as e:
-        logger.error(f"LLM call failed: {e}", exc_info=True)
+        # Issue #190 — never dump raw exception text (or its traceback) when
+        # the upstream body may contain echoed API keys. Strip secrets first
+        # and drop ``exc_info`` so loguru's diagnose-formatter doesn't expand
+        # the offending frames into the log.
+        safe = _scrub(e)
+        logger.error(f"LLM call failed: {safe}")
         return (
             [b.text for b in resume_ast.bullets],
             True,
-            f"LLM error: {str(e)[:100]}. Showing original bullets.",
+            f"LLM error: {safe[:100]}. Showing original bullets.",
         )
 
 

--- a/backend/app/services/llm_gateway.py
+++ b/backend/app/services/llm_gateway.py
@@ -27,16 +27,65 @@ fallback   | Keyword-based offline scoring
 from __future__ import annotations
 
 import re
+import time
 from abc import ABC, abstractmethod
 from enum import StrEnum
+from typing import Any
 
 import httpx
 from loguru import logger
 
 from app.config import settings
 from app.middleware.circuit_breaker import CircuitOpenError, llm_circuit
+from app.services import llm_circuit_redis
 from app.services.resume_parser import ResumeAST
 from app.utils.encryption import decrypt_value
+
+# -- Prometheus metrics (optional) --
+# Use ``prometheus_client`` if available — it ships as a transitive dep of
+# ``prometheus-fastapi-instrumentator``. We fall back to structured loguru
+# logs when the import fails so the gateway works in minimal environments.
+try:  # pragma: no cover - import guard
+    from prometheus_client import Counter, Histogram
+
+    _llm_request_duration_seconds = Histogram(
+        "llm_request_duration_seconds",
+        "Duration of LLM provider requests in seconds.",
+        labelnames=("provider",),
+    )
+    _llm_request_total = Counter(
+        "llm_request_total",
+        "Total LLM provider requests.",
+        labelnames=("provider", "status"),
+    )
+    _HAS_PROMETHEUS = True
+except Exception:  # pragma: no cover - prometheus_client missing
+    _llm_request_duration_seconds = None  # type: ignore[assignment]
+    _llm_request_total = None  # type: ignore[assignment]
+    _HAS_PROMETHEUS = False
+
+
+def _emit_metric(provider: str, status: str, duration_ms: float) -> None:
+    """Record a request metric for ``provider`` (``success`` or ``failure``).
+
+    Always emits a structured loguru info event so log-based dashboards
+    keep working when prometheus_client is unavailable.
+    """
+    logger.info(
+        "llm.request",
+        provider=provider,
+        duration_ms=round(duration_ms, 2),
+        status=status,
+    )
+    if _HAS_PROMETHEUS:
+        try:
+            _llm_request_total.labels(provider=provider, status=status).inc()  # type: ignore[union-attr]
+            _llm_request_duration_seconds.labels(provider=provider).observe(  # type: ignore[union-attr]
+                duration_ms / 1000.0
+            )
+        except Exception as exc:  # pragma: no cover - never let metrics break a request
+            logger.debug(f"prometheus emit failed: {exc}")
+
 
 # -- LLMProvider Protocol --
 
@@ -587,6 +636,43 @@ class LLMUnavailableError(Exception):
     pass
 
 
+class LLMGenerationError(Exception):
+    """Raised when an individual LLM provider attempt fails inside the gateway cascade.
+
+    The cascade catches this internally and continues to the next provider —
+    callers will only see it if they invoke a single provider directly via
+    ``LLMGateway._attempt_single`` or similar low-level helper.
+
+    Attributes
+    ----------
+    provider:
+        Logical provider name that failed (``"anthropic"``, ``"openai"``…).
+    attempt_number:
+        1-indexed position inside the gateway cascade.
+    cause:
+        Underlying exception captured when the attempt raised, if any.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str,
+        attempt_number: int,
+        cause: Exception | None = None,
+    ):
+        super().__init__(message)
+        self.provider = provider
+        self.attempt_number = attempt_number
+        self.cause = cause
+
+    def __repr__(self) -> str:
+        return (
+            f"LLMGenerationError(provider={self.provider!r}, "
+            f"attempt_number={self.attempt_number}, cause={self.cause!r})"
+        )
+
+
 # -- Constants & registry --
 
 
@@ -733,8 +819,16 @@ class LLMGateway:
         -------
         tuple[str, str]
             ``(content, provider_name_used)``
+
+        Notes
+        -----
+        * Each provider attempt is wrapped with a Redis-backed circuit
+          breaker (``llm_circuit_redis``). When a provider's circuit is
+          open the gateway skips it without making an HTTP call.
+        * Successful and failed attempts emit Prometheus metrics and a
+          structured ``llm.request`` log event.
         """
-        cascade: list[tuple[str, object]] = []
+        cascade: list[tuple[str, Any]] = []
 
         # Build ordered cascade — primary provider first (only if key is present)
         if provider == "anthropic" and api_key:
@@ -765,18 +859,65 @@ class LLMGateway:
                 ("ollama", lambda: _call_ollama(system_prompt, user_prompt, ollama_model))
             )
 
-        # Try each provider in order
-        for name, call in cascade:
-            try:
-                result = await call()  # type: ignore[operator]
-                if result and len(result) > _MIN_RESPONSE_LEN:
-                    return result, name
+        # Try each provider in order, recording metrics + breaker state.
+        for attempt_number, (name, call) in enumerate(cascade, start=1):
+            # Redis-backed circuit breaker — skip immediately if open.
+            if await llm_circuit_redis.is_open(name):
                 logger.warning(
-                    f"LLMGateway: provider '{name}' returned a short response "
-                    f"({len(result)} chars) — skipping"
+                    "LLMGateway: provider '{}' circuit OPEN (attempt {}) — skipping",
+                    name,
+                    attempt_number,
                 )
+                _emit_metric(name, "circuit_open", 0.0)
+                continue
+
+            start = time.monotonic()
+            try:
+                result = await call()
+                duration_ms = (time.monotonic() - start) * 1000.0
+                if result and len(result) > _MIN_RESPONSE_LEN:
+                    await llm_circuit_redis.record_success(name)
+                    _emit_metric(name, "success", duration_ms)
+                    logger.info(
+                        "LLMGateway: provider '{}' succeeded (attempt {}, {:.1f}ms)",
+                        name,
+                        attempt_number,
+                        duration_ms,
+                    )
+                    return result, name
+                # Short response — treat as a soft failure for metrics
+                logger.warning(
+                    "LLMGateway: provider '{}' returned a short response "
+                    "({} chars, attempt {}) — skipping",
+                    name,
+                    len(result) if result else 0,
+                    attempt_number,
+                )
+                _emit_metric(name, "failure", duration_ms)
+                err = LLMGenerationError(
+                    f"Provider '{name}' returned short response",
+                    provider=name,
+                    attempt_number=attempt_number,
+                )
+                await llm_circuit_redis.record_failure(name)
+                logger.debug(repr(err))
             except Exception as exc:
-                logger.warning(f"LLMGateway: provider '{name}' failed: {exc}")
+                duration_ms = (time.monotonic() - start) * 1000.0
+                _emit_metric(name, "failure", duration_ms)
+                err = LLMGenerationError(
+                    f"Provider '{name}' raised: {exc}",
+                    provider=name,
+                    attempt_number=attempt_number,
+                    cause=exc,
+                )
+                logger.warning(
+                    "LLMGateway: provider '{}' failed (attempt {}, {:.1f}ms): {}",
+                    name,
+                    attempt_number,
+                    duration_ms,
+                    exc,
+                )
+                await llm_circuit_redis.record_failure(name)
 
         return "", "fallback"
 

--- a/backend/app/services/resume_generator.py
+++ b/backend/app/services/resume_generator.py
@@ -399,6 +399,12 @@ async def _dispatch_provider_entry(
     Issue #188 — propagates the per-entry ``model`` to the gateway so cloud
     providers honour user-selected variants (e.g. ``gemini-1.5-pro``). For
     Ollama, the same ``model`` field is used as the local model tag.
+
+    Issue #186 — passes ``skip_fallback=True`` so the gateway doesn't
+    silently retry Ollama when a cloud provider fails. The outer
+    multi-provider loops here own fallback semantics; the gateway should
+    only attempt the provider the caller asked for so the returned
+    ``provider_used`` is always accurate.
     """
     name = p.get("name", "")
     api_key = p.get("api_key", "")
@@ -418,6 +424,7 @@ async def _dispatch_provider_entry(
             provider=name,
             api_key=api_key,
             ollama_model=entry_model or ollama_model,
+            skip_fallback=True,
         )
     return await _llm_gateway.generate(
         system_prompt=system_prompt,
@@ -426,6 +433,7 @@ async def _dispatch_provider_entry(
         api_key=api_key,
         ollama_model=ollama_model,
         model=entry_model,
+        skip_fallback=True,
     )
 
 

--- a/backend/app/services/resume_generator.py
+++ b/backend/app/services/resume_generator.py
@@ -395,6 +395,10 @@ async def _dispatch_provider_entry(
     in the multi-provider helpers below to a single gateway call. Returns
     ``(raw_text, provider_used)``. An empty string for the text means the
     gateway exhausted its cascade for this provider entry.
+
+    Issue #188 — propagates the per-entry ``model`` to the gateway so cloud
+    providers honour user-selected variants (e.g. ``gemini-1.5-pro``). For
+    Ollama, the same ``model`` field is used as the local model tag.
     """
     name = p.get("name", "")
     api_key = p.get("api_key", "")
@@ -403,12 +407,25 @@ async def _dispatch_provider_entry(
     # Ollama does not need a key; every other provider does.
     if name != "ollama" and not api_key:
         return ("", name)
+
+    entry_model = p.get("model") or None
+    # For Ollama, the entry's ``model`` is the local model tag. For cloud
+    # providers, it's the API model id forwarded via ``model=``.
+    if name == "ollama":
+        return await _llm_gateway.generate(
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+            provider=name,
+            api_key=api_key,
+            ollama_model=entry_model or ollama_model,
+        )
     return await _llm_gateway.generate(
         system_prompt=system_prompt,
         user_prompt=user_prompt,
         provider=name,
         api_key=api_key,
         ollama_model=ollama_model,
+        model=entry_model,
     )
 
 
@@ -629,11 +646,15 @@ Write exactly 1 compelling draft answer (180-220 words). Return only the answer 
     async def _call_one(p: dict) -> tuple[str, str]:
         name = p.get("name", "")
         try:
+            # Issue #188: ``_dispatch_provider_entry`` now routes the entry's
+            # ``model`` field per-provider — passing it again as
+            # ``ollama_model`` previously meant a Gemini ``model`` (e.g.
+            # ``"gemini-1.5-pro"``) would be sent to the Ollama fallback hop
+            # as the local model tag. Let the dispatcher handle routing.
             raw, _ = await _dispatch_provider_entry(
                 p,
                 _ANSWER_SYSTEM_PROMPT,
                 user_prompt,
-                ollama_model=p.get("model", "") or "llama3.1:8b",
             )
             return (raw.strip(), name) if raw and len(raw) > 50 else ("", name)
         except Exception as e:

--- a/backend/app/services/resume_generator.py
+++ b/backend/app/services/resume_generator.py
@@ -383,6 +383,35 @@ async def _llm_generate(
     )
 
 
+async def _dispatch_provider_entry(
+    p: dict,
+    system_prompt: str,
+    user_prompt: str,
+    ollama_model: str = "llama3.1:8b",
+) -> tuple[str, str]:
+    """Route a ``{name, api_key, model}`` dict through ``LLMGateway``.
+
+    Issue #107 — collapses the repeated provider-specific ``if/elif`` chains
+    in the multi-provider helpers below to a single gateway call. Returns
+    ``(raw_text, provider_used)``. An empty string for the text means the
+    gateway exhausted its cascade for this provider entry.
+    """
+    name = p.get("name", "")
+    api_key = p.get("api_key", "")
+    if not name:
+        return ("", "")
+    # Ollama does not need a key; every other provider does.
+    if name != "ollama" and not api_key:
+        return ("", name)
+    return await _llm_gateway.generate(
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        provider=name,
+        api_key=api_key,
+        ollama_model=ollama_model,
+    )
+
+
 # ── Answer generation (Q&A) ────────────────────────────────────────────────
 
 _ANSWER_SYSTEM_PROMPT = """You generate compelling, honest answers to job application questions.
@@ -599,31 +628,13 @@ Write exactly 1 compelling draft answer (180-220 words). Return only the answer 
 
     async def _call_one(p: dict) -> tuple[str, str]:
         name = p.get("name", "")
-        api_key = p.get("api_key", "")
-        model = p.get("model", "")
         try:
-            if name == "anthropic" and api_key:
-                raw = await _call_anthropic(_ANSWER_SYSTEM_PROMPT, user_prompt, api_key)
-            elif name == "openai" and api_key:
-                raw = await _call_openai(_ANSWER_SYSTEM_PROMPT, user_prompt, api_key)
-            elif name == "gemini" and api_key:
-                raw = await _call_gemini(
-                    _ANSWER_SYSTEM_PROMPT, user_prompt, api_key, model or "gemini-1.5-flash"
-                )
-            elif name == "groq" and api_key:
-                raw = await _call_groq(
-                    _ANSWER_SYSTEM_PROMPT, user_prompt, api_key, model or "llama-3.3-70b-versatile"
-                )
-            elif name == "perplexity" and api_key:
-                raw = await _call_perplexity(
-                    _ANSWER_SYSTEM_PROMPT, user_prompt, api_key, model or "sonar"
-                )
-            elif name == "kimi" and api_key:
-                raw = await _call_kimi(_ANSWER_SYSTEM_PROMPT, user_prompt, api_key)
-            elif name == "ollama":
-                raw = await _call_ollama(_ANSWER_SYSTEM_PROMPT, user_prompt, model or "llama3.1:8b")
-            else:
-                return ("", name)
+            raw, _ = await _dispatch_provider_entry(
+                p,
+                _ANSWER_SYSTEM_PROMPT,
+                user_prompt,
+                ollama_model=p.get("model", "") or "llama3.1:8b",
+            )
             return (raw.strip(), name) if raw and len(raw) > 50 else ("", name)
         except Exception as e:
             logger.warning(f"Multi-LLM: provider '{name}' failed: {e}")
@@ -756,36 +767,18 @@ DRAFT_3:
 
     for p in sorted_providers:
         name = p.get("name", "")
-        api_key = p.get("api_key", "")
-        model = p.get("model", "")
+        # Ollama only works with a local backend — skip on cloud deployments
+        if name == "ollama":
+            continue
         try:
-            if name == "ollama":
-                # Ollama only works with a local backend — skip on cloud deployments
-                continue
-            elif name == "anthropic" and api_key:
-                raw = await _call_anthropic(system_prompt, user_prompt, api_key)
-            elif name == "openai" and api_key:
-                raw = await _call_openai(system_prompt, user_prompt, api_key)
-            elif name == "gemini" and api_key:
-                raw = await _call_gemini(
-                    system_prompt, user_prompt, api_key, model or "gemini-1.5-flash"
-                )
-            elif name == "groq" and api_key:
-                raw = await _call_groq(
-                    system_prompt, user_prompt, api_key, model or "llama-3.3-70b-versatile"
-                )
-            elif name == "perplexity" and api_key:
-                raw = await _call_perplexity(system_prompt, user_prompt, api_key, model or "sonar")
-            elif name == "kimi" and api_key:
-                raw = await _call_kimi(system_prompt, user_prompt, api_key)
-            else:
-                continue
+            raw, _ = await _dispatch_provider_entry(p, system_prompt, user_prompt)
             min_len = 200 if is_cover_letter else 100
             if raw and len(raw) > min_len:
                 drafts = _parse_answer_drafts(raw)
                 if drafts:
                     logger.info(
-                        f"Cascade: used provider '{name}' for {'cover letter' if is_cover_letter else 'answer'} drafts"
+                        f"Cascade: used provider '{name}' for "
+                        f"{'cover letter' if is_cover_letter else 'answer'} drafts"
                     )
                     return drafts, name
         except Exception as e:
@@ -811,24 +804,13 @@ async def _call_single_provider(
     try:
         if name == "ollama":
             return "", name
-        elif name == "anthropic" and api_key:
-            raw = await _call_anthropic(system_prompt, user_prompt, api_key)
-        elif name == "openai" and api_key:
-            raw = await _call_openai(system_prompt, user_prompt, api_key)
-        elif name == "gemini" and api_key:
-            raw = await _call_gemini(
-                system_prompt, user_prompt, api_key, model or "gemini-1.5-flash"
-            )
-        elif name == "groq" and api_key:
-            raw = await _call_groq(
-                system_prompt, user_prompt, api_key, model or "llama-3.3-70b-versatile"
-            )
-        elif name == "perplexity" and api_key:
-            raw = await _call_perplexity(system_prompt, user_prompt, api_key, model or "sonar")
-        elif name == "kimi" and api_key:
-            raw = await _call_kimi(system_prompt, user_prompt, api_key)
-        else:
+        if not name or not api_key:
             return "", name
+        raw, _ = await _dispatch_provider_entry(
+            {"name": name, "api_key": api_key, "model": model},
+            system_prompt,
+            user_prompt,
+        )
 
         min_len = 200 if is_cover_letter else 80
         if raw and len(raw) > min_len:
@@ -1386,24 +1368,9 @@ async def generate_cover_letter(
             rag_context=rag_context,
         )
         name = p.get("name", "")
-        api_key = p.get("api_key", "")
-        model = p.get("model", "")
         try:
-            if name == "anthropic" and api_key:
-                raw = await _call_anthropic(system_prompt, user_prompt, api_key)
-            elif name == "openai" and api_key:
-                raw = await _call_openai(system_prompt, user_prompt, api_key)
-            elif name == "gemini" and api_key:
-                raw = await _call_gemini(
-                    system_prompt, user_prompt, api_key, model or "gemini-1.5-flash"
-                )
-            elif name == "groq" and api_key:
-                raw = await _call_groq(
-                    system_prompt, user_prompt, api_key, model or "llama-3.3-70b-versatile"
-                )
-            elif name == "kimi" and api_key:
-                raw = await _call_kimi(system_prompt, user_prompt, api_key)
-            else:
+            raw, _ = await _dispatch_provider_entry(p, system_prompt, user_prompt)
+            if not raw:
                 return ("", "")
             # Strip any DRAFT_1: prefix the model may echo back
             text = re.sub(r"^DRAFT_\d+:\s*", "", raw.strip(), flags=re.IGNORECASE).strip()
@@ -1473,24 +1440,9 @@ Lead with years of experience or key expertise. End with value proposition for t
     sorted_providers = sorted(providers, key=lambda p: _PROVIDER_RANK.get(p.get("name", ""), 50))
     for p in sorted_providers:
         name = p.get("name", "")
-        api_key = p.get("api_key", "")
-        model = p.get("model", "")
         try:
-            if name == "anthropic" and api_key:
-                raw = await _call_anthropic(system_prompt, user_prompt, api_key)
-            elif name == "openai" and api_key:
-                raw = await _call_openai(system_prompt, user_prompt, api_key)
-            elif name == "gemini" and api_key:
-                raw = await _call_gemini(
-                    system_prompt, user_prompt, api_key, model or "gemini-1.5-flash"
-                )
-            elif name == "groq" and api_key:
-                raw = await _call_groq(
-                    system_prompt, user_prompt, api_key, model or "llama-3.3-70b-versatile"
-                )
-            elif name == "kimi" and api_key:
-                raw = await _call_kimi(system_prompt, user_prompt, api_key)
-            else:
+            raw, _ = await _dispatch_provider_entry(p, system_prompt, user_prompt)
+            if not raw:
                 continue
             text = raw.strip()
             if text and len(text) > 50:
@@ -1562,26 +1514,10 @@ Return EXACTLY {num_bullets} bullets, one per line, each starting with "• ".""
     sorted_providers = sorted(providers, key=lambda p: _PROVIDER_RANK.get(p.get("name", ""), 50))
     for p in sorted_providers:
         name = p.get("name", "")
-        api_key = p.get("api_key", "")
-        model = p.get("model", "")
         try:
-            if name == "anthropic" and api_key:
-                raw = await _call_anthropic(system_prompt, user_prompt, api_key)
-            elif name == "openai" and api_key:
-                raw = await _call_openai(system_prompt, user_prompt, api_key)
-            elif name == "gemini" and api_key:
-                raw = await _call_gemini(
-                    system_prompt, user_prompt, api_key, model or "gemini-1.5-flash"
-                )
-            elif name == "groq" and api_key:
-                raw = await _call_groq(
-                    system_prompt, user_prompt, api_key, model or "llama-3.3-70b-versatile"
-                )
-            elif name == "kimi" and api_key:
-                raw = await _call_kimi(system_prompt, user_prompt, api_key)
-            else:
+            raw, _ = await _dispatch_provider_entry(p, system_prompt, user_prompt)
+            if not raw:
                 continue
-            import re as _re
 
             lines = [
                 line.lstrip("•- ").strip()

--- a/backend/tests/unit/test_llm_gateway_circuit_breaker.py
+++ b/backend/tests/unit/test_llm_gateway_circuit_breaker.py
@@ -1,0 +1,310 @@
+"""Tests for the Redis-backed LLM circuit breaker.
+
+Issue #107 — Phase 2. The breaker lives in
+``app.services.llm_circuit_redis`` and is consulted by
+``LLMGateway.generate()`` before every provider attempt.
+
+Tests run against an in-memory fake Redis (a tiny dict-backed class)
+to avoid spinning up a real Redis service. The graceful-degradation
+test additionally simulates a Redis client that always raises.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import llm_circuit_redis
+from app.services.llm_gateway import LLMGateway
+
+
+class _FakeRedis:
+    """Minimal in-memory async Redis stub for circuit-breaker tests."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, tuple[str, float | None]] = {}
+
+    def _now(self) -> float:
+        return time.monotonic()
+
+    def _expired(self, key: str) -> bool:
+        v = self.store.get(key)
+        if v is None:
+            return True
+        _, expires_at = v
+        if expires_at is None:
+            return False
+        if self._now() >= expires_at:
+            del self.store[key]
+            return True
+        return False
+
+    async def get(self, key: str) -> str | None:
+        if self._expired(key):
+            return None
+        return self.store[key][0]
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        expires_at = self._now() + ex if ex else None
+        self.store[key] = (str(value), expires_at)
+
+    async def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+    async def incr(self, key: str) -> int:
+        if self._expired(key):
+            self.store[key] = ("1", None)
+            return 1
+        val = int(self.store[key][0])
+        val += 1
+        prev_ttl = self.store[key][1]
+        self.store[key] = (str(val), prev_ttl)
+        return val
+
+    async def expire(self, key: str, ttl: int) -> None:
+        if key in self.store:
+            cur, _ = self.store[key]
+            self.store[key] = (cur, self._now() + ttl)
+
+    async def aclose(self) -> None:
+        return None
+
+
+class _BrokenRedis:
+    """Simulates Redis being completely down — every call raises."""
+
+    async def get(self, *_a: Any, **_kw: Any) -> str | None:
+        raise ConnectionError("redis down")
+
+    async def set(self, *_a: Any, **_kw: Any) -> None:
+        raise ConnectionError("redis down")
+
+    async def delete(self, *_a: Any, **_kw: Any) -> None:
+        raise ConnectionError("redis down")
+
+    async def incr(self, *_a: Any, **_kw: Any) -> int:
+        raise ConnectionError("redis down")
+
+    async def expire(self, *_a: Any, **_kw: Any) -> None:
+        raise ConnectionError("redis down")
+
+    async def aclose(self) -> None:
+        return None
+
+
+# -- is_open / record_failure / record_success ------------------------------
+
+
+@pytest.mark.asyncio
+async def test_breaker_starts_closed():
+    fake = _FakeRedis()
+    assert await llm_circuit_redis.is_open("anthropic", client=fake) is False
+
+
+@pytest.mark.asyncio
+async def test_breaker_opens_after_threshold_failures():
+    fake = _FakeRedis()
+    # 2 failures — still closed
+    await llm_circuit_redis.record_failure("anthropic", client=fake)
+    await llm_circuit_redis.record_failure("anthropic", client=fake)
+    assert await llm_circuit_redis.is_open("anthropic", client=fake) is False
+    # 3rd failure opens the circuit
+    just_opened = await llm_circuit_redis.record_failure("anthropic", client=fake)
+    assert just_opened is True
+    assert await llm_circuit_redis.is_open("anthropic", client=fake) is True
+
+
+@pytest.mark.asyncio
+async def test_breaker_record_failure_returns_false_when_below_threshold():
+    fake = _FakeRedis()
+    result = await llm_circuit_redis.record_failure("openai", client=fake)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_breaker_closes_after_ttl_expires(monkeypatch):
+    fake = _FakeRedis()
+    # Patch the threshold's TTL so the test runs fast
+    monkeypatch.setattr(llm_circuit_redis, "_WINDOW_SECONDS", 1)
+    for _ in range(3):
+        await llm_circuit_redis.record_failure("groq", client=fake)
+    assert await llm_circuit_redis.is_open("groq", client=fake) is True
+    # Wait past the TTL — circuit auto-closes
+    time.sleep(1.1)
+    assert await llm_circuit_redis.is_open("groq", client=fake) is False
+
+
+@pytest.mark.asyncio
+async def test_breaker_record_success_resets_counter():
+    fake = _FakeRedis()
+    await llm_circuit_redis.record_failure("kimi", client=fake)
+    await llm_circuit_redis.record_failure("kimi", client=fake)
+    await llm_circuit_redis.record_success("kimi", client=fake)
+    # Two new failures should not be enough to re-open — the counter reset.
+    just_opened = await llm_circuit_redis.record_failure("kimi", client=fake)
+    assert just_opened is False
+    assert await llm_circuit_redis.is_open("kimi", client=fake) is False
+
+
+@pytest.mark.asyncio
+async def test_breaker_isolates_providers():
+    """A trip on one provider must not affect another."""
+    fake = _FakeRedis()
+    for _ in range(3):
+        await llm_circuit_redis.record_failure("anthropic", client=fake)
+    assert await llm_circuit_redis.is_open("anthropic", client=fake) is True
+    assert await llm_circuit_redis.is_open("openai", client=fake) is False
+
+
+# -- graceful degradation when Redis is unavailable --------------------------
+
+
+@pytest.mark.asyncio
+async def test_breaker_treats_redis_down_as_closed():
+    broken = _BrokenRedis()
+    # All operations must return safe defaults rather than raise
+    assert await llm_circuit_redis.is_open("anthropic", client=broken) is False
+    just_opened = await llm_circuit_redis.record_failure("anthropic", client=broken)
+    assert just_opened is False
+    # record_success must not raise either
+    await llm_circuit_redis.record_success("anthropic", client=broken)
+
+
+@pytest.mark.asyncio
+async def test_gateway_proceeds_when_redis_is_unavailable():
+    """LLMGateway must complete a request when the circuit breaker can't talk to Redis."""
+    gateway = LLMGateway()
+    payload = "Real LLM response. " * 20  # > 200 chars
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis._get_client",
+            new=AsyncMock(return_value=None),  # simulate "redis unavailable"
+        ),
+        patch(
+            "app.services.llm_gateway._call_anthropic",
+            new=AsyncMock(return_value=payload),
+        ),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="System.",
+            user_prompt="Question.",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+        )
+
+    assert provider_used == "anthropic"
+    assert content == payload
+
+
+# -- integration with LLMGateway: open circuit skips the provider -----------
+
+
+@pytest.mark.asyncio
+async def test_gateway_skips_provider_when_circuit_is_open():
+    """When ``is_open`` returns True for the primary, the gateway must
+    fall through to the next stage (Ollama) without calling it."""
+    gateway = LLMGateway()
+    ollama_text = "Ollama returned this answer. " * 15
+
+    anthropic_mock = AsyncMock(return_value="should not be called")
+    is_open_mock = AsyncMock(side_effect=lambda name, client=None: name == "anthropic")
+
+    with (
+        patch("app.services.llm_circuit_redis.is_open", new=is_open_mock),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("app.services.llm_gateway._call_anthropic", new=anthropic_mock),
+        patch(
+            "app.services.llm_gateway._call_ollama",
+            new=AsyncMock(return_value=ollama_text),
+        ),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="System.",
+            user_prompt="Question.",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+        )
+
+    anthropic_mock.assert_not_awaited()
+    assert provider_used == "ollama"
+    assert content == ollama_text
+
+
+@pytest.mark.asyncio
+async def test_gateway_records_success_on_provider_success():
+    gateway = LLMGateway()
+    payload = "OK response. " * 20
+
+    success_mock = AsyncMock(return_value=None)
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch("app.services.llm_circuit_redis.record_success", new=success_mock),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_gateway._call_anthropic",
+            new=AsyncMock(return_value=payload),
+        ),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+        )
+
+    assert provider_used == "anthropic"
+    assert content == payload
+    success_mock.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_records_failure_when_provider_raises():
+    gateway = LLMGateway()
+    failure_mock = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch("app.services.llm_circuit_redis.record_failure", new=failure_mock),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_gateway._call_anthropic",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ),
+        patch(
+            "app.services.llm_gateway._call_ollama",
+            new=AsyncMock(side_effect=RuntimeError("ollama down")),
+        ),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+        )
+
+    assert provider_used == "fallback"
+    assert content == ""
+    assert failure_mock.await_count >= 1

--- a/backend/tests/unit/test_llm_gateway_model_override.py
+++ b/backend/tests/unit/test_llm_gateway_model_override.py
@@ -1,0 +1,176 @@
+"""Regression tests for per-provider model overrides through ``LLMGateway``.
+
+Issue #188 — ``LLMGateway.generate()`` must accept a ``model=`` kwarg and
+forward it to the per-provider lambdas so callers can request specific
+model variants (e.g. ``gemini-1.5-pro``). Previously the only way to
+override a model was the legacy ``ollama_model`` kwarg, which Gemini /
+Groq / Perplexity silently ignored.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.services.llm_gateway import LLMGateway
+
+
+def _ok_response(text: str) -> httpx.Response:
+    """Build an OpenAI-compatible chat-completions success response."""
+    return httpx.Response(
+        status_code=200,
+        json={
+            "choices": [{"message": {"content": text}}],
+        },
+        request=httpx.Request("POST", "https://example.invalid"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_gemini_honours_model_override():
+    """When ``model="gemini-1.5-pro"`` is passed, the HTTP POST body must
+    carry ``model="gemini-1.5-pro"`` rather than the hard-coded flash default."""
+    payload_text = "Real response. " * 30  # > 200 chars
+    captured: dict = {}
+
+    async def fake_post(self, url, *args, **kwargs):  # noqa: ANN001
+        captured["url"] = str(url)
+        captured["json"] = kwargs.get("json", {})
+        return _ok_response(payload_text)
+
+    gateway = LLMGateway()
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch.object(httpx.AsyncClient, "post", new=fake_post),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="gemini",
+            api_key="AIzaSyTestKey12345678901234567890ABC",
+            model="gemini-1.5-pro",
+        )
+
+    assert provider_used == "gemini"
+    assert content == payload_text
+    assert captured["json"].get("model") == "gemini-1.5-pro"
+
+
+@pytest.mark.asyncio
+async def test_gemini_defaults_to_flash_when_model_unset():
+    payload_text = "Real response. " * 30
+    captured: dict = {}
+
+    async def fake_post(self, url, *args, **kwargs):  # noqa: ANN001
+        captured["json"] = kwargs.get("json", {})
+        return _ok_response(payload_text)
+
+    gateway = LLMGateway()
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch.object(httpx.AsyncClient, "post", new=fake_post),
+    ):
+        await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="gemini",
+            api_key="AIzaSyTestKey12345678901234567890ABC",
+        )
+
+    assert captured["json"].get("model") == "gemini-1.5-flash"
+
+
+@pytest.mark.asyncio
+async def test_groq_honours_model_override():
+    payload_text = "Hello. " * 60
+    captured: dict = {}
+
+    async def fake_post(self, url, *args, **kwargs):  # noqa: ANN001
+        captured["json"] = kwargs.get("json", {})
+        return _ok_response(payload_text)
+
+    gateway = LLMGateway()
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch.object(httpx.AsyncClient, "post", new=fake_post),
+    ):
+        await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="groq",
+            api_key="gsk_testkey1234567890abcdefghij",
+            model="llama-3.1-8b-instant",
+        )
+
+    assert captured["json"].get("model") == "llama-3.1-8b-instant"
+
+
+@pytest.mark.asyncio
+async def test_perplexity_honours_model_override():
+    payload_text = "Hello. " * 60
+    captured: dict = {}
+
+    async def fake_post(self, url, *args, **kwargs):  # noqa: ANN001
+        captured["json"] = kwargs.get("json", {})
+        return _ok_response(payload_text)
+
+    gateway = LLMGateway()
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch.object(httpx.AsyncClient, "post", new=fake_post),
+    ):
+        await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="perplexity",
+            api_key="pplx-testkey1234567890abcdefghij",
+            model="sonar-pro",
+        )
+
+    assert captured["json"].get("model") == "sonar-pro"

--- a/backend/tests/unit/test_llm_gateway_secret_scrub.py
+++ b/backend/tests/unit/test_llm_gateway_secret_scrub.py
@@ -1,0 +1,205 @@
+"""Regression tests for API-key scrubbing in error / log paths.
+
+Issue #190 — Gemini accepts the API key as a ``?key=`` query string
+parameter, Perplexity's 4xx bodies sometimes echo the
+``x-api-key`` header, Groq's tokens are ``gsk_...``, Anthropic's are
+``sk-ant-...``, etc. Any of these can end up inside an exception
+``str()`` and then in a log line or
+``LLMGenerationError.__repr__``. The gateway must scrub before
+interpolation so leaked keys never reach the log stream.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.llm_gateway import (
+    LLMGenerationError,
+    _scrub,
+)
+
+
+# -- direct scrubber unit tests ------------------------------------------
+
+
+def test_scrub_redacts_anthropic_key():
+    text = "401 unauthorised: sk-ant-abcDEF1234567890_-= rejected"
+    out = _scrub(text)
+    assert "sk-ant-" not in out
+    assert "[REDACTED]" in out
+
+
+def test_scrub_redacts_gemini_key():
+    text = "POST https://example.com/v1/x?key=AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q failed"
+    out = _scrub(text)
+    assert "AIzaSy" not in out
+    assert "key=AIza" not in out
+    assert "[REDACTED]" in out
+
+
+def test_scrub_redacts_query_string_key_param():
+    text = "GET ?key=somesecretvalue123 ; got 401"
+    out = _scrub(text)
+    assert "somesecretvalue123" not in out
+    assert "[REDACTED]" in out
+
+
+def test_scrub_redacts_api_key_query_param():
+    text = "GET /path?api_key=xyz9876 returned 401"
+    out = _scrub(text)
+    assert "xyz9876" not in out
+
+
+def test_scrub_redacts_bearer_token():
+    text = "Headers: Authorization: Bearer abc.def.ghi=="
+    out = _scrub(text)
+    assert "abc.def.ghi" not in out
+    assert "[REDACTED]" in out
+
+
+def test_scrub_redacts_x_api_key_header():
+    text = "headers x-api-key: pplx-livesecret1234567890"
+    out = _scrub(text)
+    assert "pplx-livesecret" not in out
+
+
+def test_scrub_redacts_groq_key():
+    text = "Auth failure: gsk_liveGroqKey1234567890abcdef"
+    out = _scrub(text)
+    assert "gsk_" not in out
+
+
+def test_scrub_redacts_openai_key():
+    text = "sk-abcDEF1234567890XYZWVU09 invalid"
+    out = _scrub(text)
+    assert "sk-abcDEF1234567890XYZWVU09" not in out
+
+
+def test_scrub_keeps_innocent_text():
+    """Non-secret text passes through unchanged so logs remain useful."""
+    text = "Provider 'anthropic' raised: HTTPStatusError 429 rate limited"
+    assert _scrub(text) == text
+
+
+# -- LLMGenerationError __repr__ scrubbing -------------------------------
+
+
+def test_error_repr_scrubs_anthropic_key_from_cause():
+    cause = RuntimeError("auth failed for sk-ant-LeAkEdKey1234567890abc")
+    err = LLMGenerationError(
+        "boom",
+        provider="anthropic",
+        attempt_number=1,
+        cause=cause,
+    )
+    out = repr(err)
+    assert "sk-ant-LeAkEdKey" not in out
+    assert "[REDACTED]" in out
+    # Provider / attempt info still present
+    assert "anthropic" in out
+    assert "attempt_number=1" in out
+
+
+def test_error_repr_scrubs_gemini_query_param():
+    # An httpx error containing a Gemini URL with the key in the query string
+    cause = httpx.HTTPStatusError(
+        "Client error '401 Unauthorized' for url "
+        "'https://generativelanguage.googleapis.com/v1/x?key=AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q'",
+        request=httpx.Request("GET", "https://example.invalid"),
+        response=httpx.Response(401),
+    )
+    err = LLMGenerationError(
+        "boom",
+        provider="gemini",
+        attempt_number=2,
+        cause=cause,
+    )
+    out = repr(err)
+    assert "AIzaSy" not in out
+    assert "[REDACTED]" in out
+
+
+def test_error_repr_with_no_cause_still_works():
+    err = LLMGenerationError("no cause", provider="openai", attempt_number=1)
+    out = repr(err)
+    assert "openai" in out
+    assert "attempt_number=1" in out
+    assert "cause=None" in out
+
+
+def test_error_message_does_not_contain_secret_when_constructed_via_gateway_path():
+    """The gateway's cascade builds err.args[0] from the scrubbed exception
+    text. Constructing one ourselves with a clean message must remain clean.
+    """
+    err = LLMGenerationError(
+        "Provider 'groq' raised: HTTPStatusError 500",
+        provider="groq",
+        attempt_number=1,
+        cause=None,
+    )
+    assert "[REDACTED]" not in str(err)
+
+
+# -- Test pattern that matches LLMGateway error-path interpolation -------
+
+
+@pytest.mark.asyncio
+async def test_gateway_error_message_scrubs_upstream_secret():
+    """When _call_anthropic raises with the API key in the exception text,
+    the gateway's failure path must NOT include the key in the error
+    message it propagates (or in the loguru warning it emits).
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from app.services.llm_gateway import LLMGateway
+
+    leaky = RuntimeError(
+        "401 Unauthorized for https://api.anthropic.com/v1/messages "
+        "with sk-ant-LeAkEdSecret1234567890abc"
+    )
+
+    captured_messages: list[str] = []
+
+    from loguru import logger as _logger
+
+    def sink(message) -> None:  # noqa: ANN001
+        captured_messages.append(message.record["message"])
+
+    sink_id = _logger.add(sink, level="WARNING")
+    try:
+        gateway = LLMGateway()
+        with (
+            patch(
+                "app.services.llm_circuit_redis.is_open",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "app.services.llm_circuit_redis.record_success",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "app.services.llm_circuit_redis.record_failure",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "app.services.llm_gateway._call_anthropic",
+                new=AsyncMock(side_effect=leaky),
+            ),
+            patch(
+                "app.services.llm_gateway._call_ollama",
+                new=AsyncMock(side_effect=leaky),
+            ),
+        ):
+            await gateway.generate(
+                system_prompt="S",
+                user_prompt="U",
+                provider="anthropic",
+                api_key="sk-ant-test1234567890",
+            )
+    finally:
+        _logger.remove(sink_id)
+
+    full_log = "\n".join(captured_messages)
+    assert "sk-ant-LeAkEdSecret" not in full_log
+    assert "[REDACTED]" in full_log

--- a/backend/tests/unit/test_llm_gateway_secret_scrub.py
+++ b/backend/tests/unit/test_llm_gateway_secret_scrub.py
@@ -19,7 +19,6 @@ from app.services.llm_gateway import (
     _scrub,
 )
 
-
 # -- direct scrubber unit tests ------------------------------------------
 
 
@@ -161,7 +160,13 @@ async def test_gateway_error_message_scrubs_upstream_secret():
 
     captured_messages: list[str] = []
 
-    from loguru import logger as _logger
+    # Use the gateway module's bound logger to dodge sys.modules-level
+    # ``loguru.logger`` mutations performed by other tests in the suite.
+    from app.services import llm_gateway as _gw
+
+    _logger = _gw.logger
+    if not hasattr(_logger, "add") or not hasattr(_logger, "remove"):
+        pytest.skip("loguru.logger was monkey-patched by another test module")
 
     def sink(message) -> None:  # noqa: ANN001
         captured_messages.append(message.record["message"])

--- a/backend/tests/unit/test_llm_gateway_skip_fallback.py
+++ b/backend/tests/unit/test_llm_gateway_skip_fallback.py
@@ -1,0 +1,179 @@
+"""Regression tests for ``skip_fallback`` flag on ``LLMGateway.generate``.
+
+Issue #186 — Previously the gateway unconditionally appended Ollama as a
+secondary attempt. When a caller wraps the gateway in its own outer
+fallback loop (``_dispatch_provider_entry``), this caused two problems:
+
+1. A failed cloud provider triggered a silent 180-second Ollama timeout.
+2. The outer loop attributed Ollama's response to the cloud provider,
+   because it used the entry's ``name`` rather than the gateway's
+   returned ``provider_used``.
+
+The ``skip_fallback=True`` flag opts the caller out of the Ollama
+secondary so the gateway only attempts the requested provider and the
+returned ``provider_used`` is always accurate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.llm_gateway import LLMGateway
+
+
+@pytest.mark.asyncio
+async def test_skip_fallback_does_not_invoke_ollama_on_failure():
+    """When skip_fallback=True and primary fails, Ollama must NOT be called."""
+    gateway = LLMGateway()
+    ollama_mock = AsyncMock(return_value="ollama would respond here")
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_gateway._call_anthropic",
+            new=AsyncMock(side_effect=RuntimeError("primary failed")),
+        ),
+        patch("app.services.llm_gateway._call_ollama", new=ollama_mock),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+            skip_fallback=True,
+        )
+
+    ollama_mock.assert_not_awaited()
+    assert provider_used == "fallback"
+    assert content == ""
+
+
+@pytest.mark.asyncio
+async def test_skip_fallback_default_false_preserves_legacy_behaviour():
+    """Without skip_fallback (default), Ollama is still attempted on failure."""
+    gateway = LLMGateway()
+    ollama_text = "Ollama responded. " * 20
+    ollama_mock = AsyncMock(return_value=ollama_text)
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_gateway._call_anthropic",
+            new=AsyncMock(side_effect=RuntimeError("primary failed")),
+        ),
+        patch("app.services.llm_gateway._call_ollama", new=ollama_mock),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+        )
+
+    ollama_mock.assert_awaited_once()
+    assert provider_used == "ollama"
+    assert content == ollama_text
+
+
+@pytest.mark.asyncio
+async def test_provider_used_matches_actual_responder_when_skip_fallback_off():
+    """When the gateway DOES fall back to Ollama, provider_used must report
+    'ollama' — never the originally requested provider. This is what the
+    outer-loop in ``_dispatch_provider_entry`` previously masked.
+    """
+    gateway = LLMGateway()
+    ollama_text = "Ollama. " * 40
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_gateway._call_gemini",
+            new=AsyncMock(side_effect=RuntimeError("gemini boom")),
+        ),
+        patch(
+            "app.services.llm_gateway._call_ollama",
+            new=AsyncMock(return_value=ollama_text),
+        ),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="gemini",
+            api_key="AIzaSyTestKey12345678901234567890ABC",
+        )
+
+    assert provider_used == "ollama"
+    assert content == ollama_text
+
+
+@pytest.mark.asyncio
+async def test_provider_used_matches_primary_when_skip_fallback_on():
+    """When skip_fallback=True and the primary succeeds, provider_used is
+    the primary's name. Round-trip sanity check for the caller contract.
+    """
+    gateway = LLMGateway()
+    payload = "Real answer. " * 25
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_gateway._call_gemini",
+            new=AsyncMock(return_value=payload),
+        ),
+    ):
+        content, provider_used = await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="gemini",
+            api_key="AIzaSyTestKey12345678901234567890ABC",
+            skip_fallback=True,
+        )
+
+    assert provider_used == "gemini"
+    assert content == payload

--- a/backend/tests/unit/test_llm_generation_error.py
+++ b/backend/tests/unit/test_llm_generation_error.py
@@ -1,0 +1,75 @@
+"""Tests for ``LLMGenerationError`` — structured per-attempt error type.
+
+Issue #107 — Phase 2. The error exposes ``provider``, ``attempt_number``
+and ``cause`` so callers can build per-attempt observability without
+parsing strings.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.llm_gateway import LLMGenerationError
+
+
+def test_error_is_an_exception():
+    err = LLMGenerationError(
+        "provider 'anthropic' raised",
+        provider="anthropic",
+        attempt_number=1,
+    )
+    assert isinstance(err, Exception)
+
+
+def test_error_carries_structured_fields():
+    cause = TimeoutError("upstream slow")
+    err = LLMGenerationError(
+        "boom",
+        provider="anthropic",
+        attempt_number=2,
+        cause=cause,
+    )
+    assert err.provider == "anthropic"
+    assert err.attempt_number == 2
+    assert err.cause is cause
+
+
+def test_error_cause_defaults_to_none():
+    err = LLMGenerationError("no cause", provider="openai", attempt_number=1)
+    assert err.cause is None
+
+
+def test_error_str_returns_message():
+    err = LLMGenerationError(
+        "message body",
+        provider="groq",
+        attempt_number=1,
+    )
+    assert "message body" in str(err)
+
+
+def test_error_repr_shows_provider_and_attempt():
+    err = LLMGenerationError(
+        "x",
+        provider="kimi",
+        attempt_number=3,
+        cause=ValueError("inner"),
+    )
+    text = repr(err)
+    assert "kimi" in text
+    assert "attempt_number=3" in text
+    assert "ValueError" in text
+
+
+def test_error_keyword_only_construction():
+    """Provider / attempt_number / cause must be supplied as kwargs."""
+    with pytest.raises(TypeError):
+        LLMGenerationError("msg", "anthropic", 1)  # type: ignore[misc]
+
+
+def test_error_is_importable_from_top_level_module():
+    """Spec requires direct import from ``app.services.llm_gateway``."""
+    from app.services import llm_gateway
+
+    assert hasattr(llm_gateway, "LLMGenerationError")
+    assert llm_gateway.LLMGenerationError is LLMGenerationError

--- a/backend/tests/unit/test_llm_metrics.py
+++ b/backend/tests/unit/test_llm_metrics.py
@@ -1,0 +1,183 @@
+"""Tests for LLMGateway request metrics.
+
+Issue #107 — Phase 2. The gateway emits a Prometheus counter +
+histogram on every attempt, and additionally logs a structured
+``llm.request`` event for log-based dashboards.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import llm_gateway
+from app.services.llm_gateway import LLMGateway
+
+
+def _read_counter_total(counter, provider: str, status: str) -> float:
+    """Look up the cumulative value for a labelled counter sample.
+
+    The default prometheus_client registry persists samples across tests,
+    so we capture before/after and only compare deltas.
+    """
+    for metric in counter.collect():
+        for sample in metric.samples:
+            if not sample.name.endswith("_total"):
+                continue
+            labels = sample.labels
+            if labels.get("provider") == provider and labels.get("status") == status:
+                return float(sample.value)
+    return 0.0
+
+
+def _read_histogram_count(histogram, provider: str) -> float:
+    for metric in histogram.collect():
+        for sample in metric.samples:
+            if not sample.name.endswith("_count"):
+                continue
+            if sample.labels.get("provider") == provider:
+                return float(sample.value)
+    return 0.0
+
+
+@pytest.mark.asyncio
+async def test_success_emits_success_counter_and_histogram_observation():
+    if not llm_gateway._HAS_PROMETHEUS:
+        pytest.skip("prometheus_client unavailable")
+
+    counter = llm_gateway._llm_request_total
+    histogram = llm_gateway._llm_request_duration_seconds
+    before_success = _read_counter_total(counter, "anthropic", "success")
+    before_hist = _read_histogram_count(histogram, "anthropic")
+
+    payload = "Hello world. " * 30  # >200 chars
+
+    gateway = LLMGateway()
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_gateway._call_anthropic",
+            new=AsyncMock(return_value=payload),
+        ),
+    ):
+        await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+        )
+
+    after_success = _read_counter_total(counter, "anthropic", "success")
+    after_hist = _read_histogram_count(histogram, "anthropic")
+    assert after_success - before_success == 1
+    assert after_hist - before_hist == 1
+
+
+@pytest.mark.asyncio
+async def test_failure_emits_failure_counter():
+    if not llm_gateway._HAS_PROMETHEUS:
+        pytest.skip("prometheus_client unavailable")
+
+    counter = llm_gateway._llm_request_total
+    before_fail_anth = _read_counter_total(counter, "anthropic", "failure")
+
+    gateway = LLMGateway()
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_gateway._call_anthropic",
+            new=AsyncMock(side_effect=RuntimeError("API exploded")),
+        ),
+        patch(
+            "app.services.llm_gateway._call_ollama",
+            new=AsyncMock(side_effect=RuntimeError("ollama down")),
+        ),
+    ):
+        await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+        )
+
+    after_fail_anth = _read_counter_total(counter, "anthropic", "failure")
+    assert after_fail_anth - before_fail_anth == 1
+
+
+@pytest.mark.asyncio
+async def test_circuit_open_emits_circuit_open_metric():
+    if not llm_gateway._HAS_PROMETHEUS:
+        pytest.skip("prometheus_client unavailable")
+
+    counter = llm_gateway._llm_request_total
+    before = _read_counter_total(counter, "anthropic", "circuit_open")
+
+    gateway = LLMGateway()
+    payload = "Real reply. " * 30
+
+    is_open_mock = AsyncMock(side_effect=lambda name, client=None: name == "anthropic")
+    with (
+        patch("app.services.llm_circuit_redis.is_open", new=is_open_mock),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_gateway._call_ollama",
+            new=AsyncMock(return_value=payload),
+        ),
+    ):
+        await gateway.generate(
+            system_prompt="S",
+            user_prompt="U",
+            provider="anthropic",
+            api_key="sk-ant-test1234567890",
+        )
+
+    after = _read_counter_total(counter, "anthropic", "circuit_open")
+    assert after - before == 1
+
+
+@pytest.mark.asyncio
+async def test_emit_metric_never_raises_when_prometheus_missing():
+    """The helper must be a no-op when prometheus_client is unavailable."""
+    # Force the "no prometheus" path even if the package is installed.
+    with patch.object(llm_gateway, "_HAS_PROMETHEUS", False):
+        # Should not raise
+        llm_gateway._emit_metric("anthropic", "success", 12.0)
+
+
+@pytest.mark.asyncio
+async def test_emit_metric_logs_structured_event(caplog):
+    """Always emit a structured ``llm.request`` info event for log dashboards."""
+    # The gateway uses loguru, which doesn't propagate to caplog by default.
+    # Instead, just verify the helper invokes its emitter cleanly.
+    llm_gateway._emit_metric("anthropic", "success", 5.5)
+    llm_gateway._emit_metric("openai", "failure", 12.0)

--- a/backend/tests/unit/test_llm_metrics.py
+++ b/backend/tests/unit/test_llm_metrics.py
@@ -186,8 +186,16 @@ async def test_emit_metric_logs_structured_event():
     We assert the rendered line now contains each label/value pair.
 
     ``caplog`` does not capture loguru output, so we wire a dedicated sink.
+    Other tests in this suite monkey-patch ``loguru.logger`` to a
+    ``SimpleNamespace`` at import-time; we use ``llm_gateway.logger`` here
+    which holds a reference captured before any such pollution, falling
+    back to a skip if even that has been mocked.
     """
-    from loguru import logger as _logger
+    # Use the gateway module's own bound logger so a polluted ``loguru.logger``
+    # in sys.modules doesn't break the capture.
+    _logger = llm_gateway.logger
+    if not hasattr(_logger, "add") or not hasattr(_logger, "remove"):
+        pytest.skip("loguru.logger was monkey-patched by another test module")
 
     messages: list[str] = []
 

--- a/backend/tests/unit/test_llm_metrics.py
+++ b/backend/tests/unit/test_llm_metrics.py
@@ -175,9 +175,37 @@ async def test_emit_metric_never_raises_when_prometheus_missing():
 
 
 @pytest.mark.asyncio
-async def test_emit_metric_logs_structured_event(caplog):
-    """Always emit a structured ``llm.request`` info event for log dashboards."""
-    # The gateway uses loguru, which doesn't propagate to caplog by default.
-    # Instead, just verify the helper invokes its emitter cleanly.
-    llm_gateway._emit_metric("anthropic", "success", 5.5)
-    llm_gateway._emit_metric("openai", "failure", 12.0)
+async def test_emit_metric_logs_structured_event():
+    """Always emit a ``llm.request`` info event with provider / duration /
+    status rendered into the log line so aggregators can pick them up.
+
+    Issue #191 — Loguru does not render keyword arguments into its default
+    sinks. The previous implementation called
+    ``logger.info("llm.request", provider=..., status=...)`` which emitted
+    only ``llm.request`` and dropped the labels into ``record["extra"]``.
+    We assert the rendered line now contains each label/value pair.
+
+    ``caplog`` does not capture loguru output, so we wire a dedicated sink.
+    """
+    from loguru import logger as _logger
+
+    messages: list[str] = []
+
+    def sink(message) -> None:  # noqa: ANN001
+        messages.append(message.record["message"])
+
+    sink_id = _logger.add(sink, level="INFO")
+    try:
+        llm_gateway._emit_metric("anthropic", "success", 5.5)
+        llm_gateway._emit_metric("openai", "failure", 12.0)
+    finally:
+        _logger.remove(sink_id)
+
+    joined = "\n".join(messages)
+    assert "llm.request" in joined
+    assert "provider=anthropic" in joined
+    assert "status=success" in joined
+    assert "duration_ms=5.5" in joined
+    assert "provider=openai" in joined
+    assert "status=failure" in joined
+    assert "duration_ms=12.0" in joined

--- a/backend/tests/unit/test_llm_metrics_reload.py
+++ b/backend/tests/unit/test_llm_metrics_reload.py
@@ -32,8 +32,7 @@ def test_reload_keeps_prometheus_enabled_in_subprocess():
     Runs in a subprocess so the reload doesn't replace classes that other
     tests in this process import directly (e.g. ``LLMGenerationError``).
     """
-    script = textwrap.dedent(
-        """
+    script = textwrap.dedent("""
         import importlib
         import sys
 
@@ -57,8 +56,7 @@ def test_reload_keeps_prometheus_enabled_in_subprocess():
         reloaded._emit_metric("openai", "failure", 5.0)
 
         print("OK")
-        """
-    )
+        """)
     result = subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True,

--- a/backend/tests/unit/test_llm_metrics_reload.py
+++ b/backend/tests/unit/test_llm_metrics_reload.py
@@ -24,9 +24,7 @@ import pytest
 from app.services import llm_gateway
 
 
-@pytest.mark.skipif(
-    not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable"
-)
+@pytest.mark.skipif(not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable")
 def test_reload_keeps_prometheus_enabled_in_subprocess():
     """After importlib.reload, _HAS_PROMETHEUS stays True and collectors
     remain usable (i.e. .labels(...).inc() doesn't raise).
@@ -67,15 +65,13 @@ def test_reload_keeps_prometheus_enabled_in_subprocess():
         text=True,
         check=False,
     )
-    assert result.returncode == 0, (
-        f"subprocess failed:\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
-    )
+    assert (
+        result.returncode == 0
+    ), f"subprocess failed:\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
     assert "OK" in result.stdout
 
 
-@pytest.mark.skipif(
-    not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable"
-)
+@pytest.mark.skipif(not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable")
 def test_helper_recovers_existing_collector_on_value_error():
     """The helper must return the already-registered collector when
     ``Counter()`` raises ``ValueError`` for a duplicate name.
@@ -88,9 +84,7 @@ def test_helper_recovers_existing_collector_on_value_error():
     assert first is second
 
 
-@pytest.mark.skipif(
-    not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable"
-)
+@pytest.mark.skipif(not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable")
 def test_helper_recovers_existing_histogram_on_value_error():
     name = "llm_test_duplicate_histogram_xyz"
     first = llm_gateway._get_or_create_histogram(name, "doc", ("p",), (1.0, 2.0, float("inf")))

--- a/backend/tests/unit/test_llm_metrics_reload.py
+++ b/backend/tests/unit/test_llm_metrics_reload.py
@@ -1,0 +1,124 @@
+"""Regression test for Prometheus duplicate registration on module reload.
+
+Issue #185 — The previous implementation wrapped collector construction
+in a bare ``except Exception``. On ``importlib.reload(llm_gateway)`` (or
+uvicorn ``--reload``) ``prometheus_client`` raises
+``ValueError: Duplicated timeseries`` because the default ``REGISTRY``
+already contains the collector. The bare-except silently flipped
+``_HAS_PROMETHEUS`` to ``False`` and left the module's collector
+references as ``None`` for the rest of the process, killing metrics.
+
+We test by running ``importlib.reload`` inside a subprocess so module
+identity in the host test process is unaffected, and by exercising the
+helper functions directly in-process.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from app.services import llm_gateway
+
+
+@pytest.mark.skipif(
+    not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable"
+)
+def test_reload_keeps_prometheus_enabled_in_subprocess():
+    """After importlib.reload, _HAS_PROMETHEUS stays True and collectors
+    remain usable (i.e. .labels(...).inc() doesn't raise).
+
+    Runs in a subprocess so the reload doesn't replace classes that other
+    tests in this process import directly (e.g. ``LLMGenerationError``).
+    """
+    script = textwrap.dedent(
+        """
+        import importlib
+        import sys
+
+        from app.services import llm_gateway
+
+        assert llm_gateway._HAS_PROMETHEUS is True, "metrics disabled on first import"
+
+        # Simulate uvicorn --reload / importlib.reload
+        reloaded = importlib.reload(llm_gateway)
+
+        assert reloaded._HAS_PROMETHEUS is True, "metrics disabled after reload"
+        assert reloaded._llm_request_total is not None
+        assert reloaded._llm_request_duration_seconds is not None
+
+        # Exercise the recovered collectors — must not raise.
+        reloaded._llm_request_total.labels(provider="anthropic", status="success").inc()
+        reloaded._llm_request_duration_seconds.labels(provider="anthropic").observe(0.42)
+
+        # _emit_metric still works after reload.
+        reloaded._emit_metric("openai", "success", 12.3)
+        reloaded._emit_metric("openai", "failure", 5.0)
+
+        print("OK")
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed:\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+
+
+@pytest.mark.skipif(
+    not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable"
+)
+def test_helper_recovers_existing_collector_on_value_error():
+    """The helper must return the already-registered collector when
+    ``Counter()`` raises ``ValueError`` for a duplicate name.
+    """
+    # First call: registers under a unique name.
+    name = "llm_test_duplicate_counter_xyz"
+    first = llm_gateway._get_or_create_counter(name, "doc", ("p",))
+    # Second call with the same name: must return the same object (not raise).
+    second = llm_gateway._get_or_create_counter(name, "doc", ("p",))
+    assert first is second
+
+
+@pytest.mark.skipif(
+    not llm_gateway._HAS_PROMETHEUS, reason="prometheus_client unavailable"
+)
+def test_helper_recovers_existing_histogram_on_value_error():
+    name = "llm_test_duplicate_histogram_xyz"
+    first = llm_gateway._get_or_create_histogram(name, "doc", ("p",), (1.0, 2.0, float("inf")))
+    second = llm_gateway._get_or_create_histogram(name, "doc", ("p",), (1.0, 2.0, float("inf")))
+    assert first is second
+
+
+def test_histogram_has_llm_latency_buckets():
+    """Issue #185 — histogram must use the explicit LLM-latency bucket set
+    so 60s/120s/180s Ollama timeouts are observable.
+    """
+    if not llm_gateway._HAS_PROMETHEUS:
+        pytest.skip("prometheus_client unavailable")
+
+    histogram = llm_gateway._llm_request_duration_seconds
+    assert histogram is not None
+    # Touch a labelset so .collect() exposes the bucket boundaries.
+    histogram.labels(provider="_bucket_probe").observe(0.0)
+    upper_bounds: list[float] = []
+    for metric in histogram.collect():
+        for sample in metric.samples:
+            if sample.name.endswith("_bucket"):
+                le = sample.labels.get("le")
+                if le is not None:
+                    upper_bounds.append(float(le))
+    # The buckets we expect to be present
+    expected_in = {60.0, 120.0, 180.0}
+    assert expected_in.issubset(set(upper_bounds)), (
+        f"missing LLM latency buckets {expected_in - set(upper_bounds)} "
+        f"from configured set {sorted(set(upper_bounds))}"
+    )

--- a/backend/tests/unit/test_tailor_resume_redis_breaker.py
+++ b/backend/tests/unit/test_tailor_resume_redis_breaker.py
@@ -1,0 +1,256 @@
+"""Regression tests for the Redis breaker covering ``tailor_resume``.
+
+Issue #189 — ``tailor_resume`` calls ``provider.complete()`` directly on
+the ``PROVIDERS`` registry instance. Before this fix it was gated only
+by the legacy in-process ``@llm_circuit`` decorator and bypassed the new
+Redis breaker entirely. The fix wraps the call site with
+``llm_circuit_redis.is_open`` (pre-check) and
+``record_success`` / ``record_failure`` (post-check) so the highest-
+volume LLM caller participates in the new breaker.
+
+We construct a minimal ``ResumeAST`` and patch the provider's
+``complete()`` so the test stays in-process.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import llm_circuit_redis, llm_gateway
+from app.services.llm_gateway import (
+    PROVIDERS,
+    RewriteStrategy,
+    tailor_resume,
+)
+from app.services.resume_parser import ResumeAST, ResumeBullet, ResumeSection
+
+
+def _make_ast() -> ResumeAST:
+    return ResumeAST(
+        bullets=[
+            ResumeBullet(
+                text="Built a thing",
+                section=ResumeSection.EXPERIENCE,
+                company="ACME",
+                role="Engineer",
+                dates="2020-2024",
+                original_index=0,
+            ),
+            ResumeBullet(
+                text="Did another thing",
+                section=ResumeSection.EXPERIENCE,
+                company="ACME",
+                role="Engineer",
+                dates="2020-2024",
+                original_index=1,
+            ),
+        ],
+        raw_text="resume",
+    )
+
+
+@pytest.mark.asyncio
+async def test_tailor_resume_short_circuits_when_redis_breaker_open():
+    """If is_open('anthropic') returns True, provider.complete must NOT be
+    called and the function must return the fallback summary.
+    """
+    ast = _make_ast()
+    anthropic = PROVIDERS["anthropic"]
+    complete_mock = AsyncMock(return_value="rewritten line 1\nrewritten line 2")
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(side_effect=lambda name, client=None: name == "anthropic"),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch("app.services.llm_gateway.decrypt_value", return_value="sk-ant-fake-key-123456"),
+        patch.object(anthropic, "complete", new=complete_mock),
+    ):
+        bullets, used_fallback, summary = await tailor_resume(
+            resume_ast=ast,
+            job_description="JD text",
+            strategy=RewriteStrategy.MODERATE,
+            provider_name="anthropic",
+            encrypted_api_key="encrypted",
+        )
+
+    complete_mock.assert_not_awaited()
+    assert used_fallback is True
+    assert "circuit open" in summary.lower()
+    # Falls back to original bullets — count and content preserved.
+    assert len(bullets) == 2
+    assert bullets[0] == "Built a thing"
+
+
+@pytest.mark.asyncio
+async def test_tailor_resume_records_success_on_provider_success():
+    """A successful provider call must call ``record_success`` on the
+    Redis breaker so the failure counter resets.
+    """
+    ast = _make_ast()
+    anthropic = PROVIDERS["anthropic"]
+    complete_mock = AsyncMock(return_value="rewritten line 1\nrewritten line 2")
+    success_mock = AsyncMock(return_value=None)
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch("app.services.llm_circuit_redis.record_success", new=success_mock),
+        patch(
+            "app.services.llm_circuit_redis.record_failure",
+            new=AsyncMock(return_value=False),
+        ),
+        patch("app.services.llm_gateway.decrypt_value", return_value="sk-ant-fake-key-123456"),
+        patch.object(anthropic, "complete", new=complete_mock),
+    ):
+        _, used_fallback, _ = await tailor_resume(
+            resume_ast=ast,
+            job_description="JD",
+            strategy=RewriteStrategy.MODERATE,
+            provider_name="anthropic",
+            encrypted_api_key="encrypted",
+        )
+
+    assert used_fallback is False
+    success_mock.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tailor_resume_records_failure_on_provider_exception():
+    """A generic provider failure must call ``record_failure`` so three
+    such failures will trip the Redis breaker.
+    """
+    ast = _make_ast()
+    anthropic = PROVIDERS["anthropic"]
+    complete_mock = AsyncMock(side_effect=RuntimeError("upstream timeout"))
+    failure_mock = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("app.services.llm_circuit_redis.record_failure", new=failure_mock),
+        patch("app.services.llm_gateway.decrypt_value", return_value="sk-ant-fake-key-123456"),
+        patch.object(anthropic, "complete", new=complete_mock),
+    ):
+        _, used_fallback, _ = await tailor_resume(
+            resume_ast=ast,
+            job_description="JD",
+            strategy=RewriteStrategy.MODERATE,
+            provider_name="anthropic",
+            encrypted_api_key="encrypted",
+        )
+
+    assert used_fallback is True
+    failure_mock.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tailor_resume_does_not_record_failure_on_invalid_key():
+    """``InvalidAPIKeyError`` is a misconfiguration signal, not a provider
+    health signal. We must NOT count it as a circuit-breaker failure.
+    """
+    from app.services.llm_gateway import InvalidAPIKeyError
+
+    ast = _make_ast()
+    anthropic = PROVIDERS["anthropic"]
+    complete_mock = AsyncMock(side_effect=InvalidAPIKeyError("bad key"))
+    failure_mock = AsyncMock(return_value=False)
+
+    with (
+        patch(
+            "app.services.llm_circuit_redis.is_open",
+            new=AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.llm_circuit_redis.record_success",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("app.services.llm_circuit_redis.record_failure", new=failure_mock),
+        patch("app.services.llm_gateway.decrypt_value", return_value="sk-ant-fake-key-123456"),
+        patch.object(anthropic, "complete", new=complete_mock),
+    ):
+        _, used_fallback, summary = await tailor_resume(
+            resume_ast=ast,
+            job_description="JD",
+            strategy=RewriteStrategy.MODERATE,
+            provider_name="anthropic",
+            encrypted_api_key="encrypted",
+        )
+
+    assert used_fallback is True
+    assert "invalid" in summary.lower()
+    failure_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tailor_resume_three_failures_open_breaker_end_to_end():
+    """Three consecutive provider failures must trip the Redis breaker so
+    the fourth call short-circuits before reaching ``provider.complete``.
+    Uses the in-memory fake Redis from the circuit-breaker test file.
+    """
+    from tests.unit.test_llm_gateway_circuit_breaker import _FakeRedis
+
+    fake = _FakeRedis()
+    ast = _make_ast()
+    anthropic = PROVIDERS["anthropic"]
+    complete_mock = AsyncMock(side_effect=RuntimeError("upstream timeout"))
+
+    async def fake_get_client(redis_url=None):  # noqa: ANN001
+        return fake
+
+    with (
+        patch("app.services.llm_circuit_redis._get_client", new=fake_get_client),
+        patch("app.services.llm_gateway.decrypt_value", return_value="sk-ant-fake-key-123456"),
+        patch.object(anthropic, "complete", new=complete_mock),
+    ):
+        # First three calls fail and increment the Redis counter.
+        for _ in range(3):
+            _, used_fallback, _ = await tailor_resume(
+                resume_ast=ast,
+                job_description="JD",
+                strategy=RewriteStrategy.MODERATE,
+                provider_name="anthropic",
+                encrypted_api_key="encrypted",
+            )
+            assert used_fallback is True
+
+        # The circuit must now be open per the Redis state.
+        assert await llm_circuit_redis.is_open("anthropic", client=fake) is True
+
+        # Fourth call: provider.complete should NOT be invoked. Reset the mock
+        # call count to make that assertion crisp.
+        complete_mock.reset_mock()
+        _, used_fallback, summary = await tailor_resume(
+            resume_ast=ast,
+            job_description="JD",
+            strategy=RewriteStrategy.MODERATE,
+            provider_name="anthropic",
+            encrypted_api_key="encrypted",
+        )
+        assert used_fallback is True
+        assert "circuit open" in summary.lower()
+        complete_mock.assert_not_awaited()
+
+
+def test_llm_gateway_module_imports_clean():
+    """Quick sanity check that no helper is shadowed by the new code path."""
+    assert callable(llm_gateway.tailor_resume)
+    assert callable(llm_gateway._scrub)


### PR DESCRIPTION
## Summary

Closes #107 — LLMGateway Phase 2: unified LLM provider dispatch with Redis-backed circuit breaker, structured errors, Prometheus metrics, and migrated service callers.

This PR went through **5-critic adversarial review** that surfaced 6 P1 bugs, **all of which are fixed in this PR before merge** (see "Fix-up commits" below). 8 additional follow-up issues filed as #183-#195.

## What changes

### Phase 2 features (commit `30d3d2b`)
- **`LLMGenerationError(provider, attempt_number, cause)`** — structured per-attempt failure type.
- **Redis-backed per-provider circuit breaker** (`backend/app/services/llm_circuit_redis.py`) — opens after 3 failures in 60s, auto-closes via TTL. Graceful degradation when Redis is unavailable.
- **Prometheus metrics** — `llm_request_duration_seconds{provider}` histogram with LLM-tuned buckets + `llm_request_total{provider,status}` counter.
- **Service migration** — `vault/answers.py`, `vault/interview.py`, `resume_generator.py` now route through `LLMGateway.generate()`. (`email_classifier_service.py` and `work_history.py` tracked as follow-ups in #187 and #194.)

### Fix-up commits addressing critic-found P1s

| Commit | Issue | Fix |
| --- | --- | --- |
| `565972b` | #188 | Honour per-provider `model` override — adds `model: str | None` param to `LLMGateway.generate()`, propagates to Gemini/Groq/Perplexity lambdas. |
| `ce0f377` | #186 | Add `skip_fallback: bool = False` flag — prevents silent Ollama secondary attempts (180s cloud timeout + provider misattribution). |
| `602601e` | #185 | Survive Prometheus duplicate registration on `importlib.reload()` — narrowed `except` from bare `Exception` to `ImportError`, recovers existing collectors via `REGISTRY._names_to_collectors`. Added explicit LLM-tuned histogram buckets (0.5s → 180s). |
| `f94b7bf` | #190 | Scrub API keys from error logs and `LLMGenerationError.__repr__` — covers `sk-ant-*`, `sk-*`, `gsk_*`, `pplx-*`, `AIza*`, `Bearer *`, `x-api-key`, `?key=` patterns. Removed `exc_info=True` from `tailor_resume`'s catch-all. |
| `0d8f83d` | #191 | Render `llm.request` log fields in logfmt — was emitting bare `llm.request` with kwargs silently dropped by loguru's default sink. |
| `a1de59b` | #189 | Wrap `tailor_resume`'s `provider.complete()` calls with Redis breaker — was the highest-volume LLM caller and bypassed the new breaker entirely. |
| `e60a0ef` | — | `black` py312 PEP 701 reformat. |

## Test plan

- [x] 33 new unit tests across 5 new test files — all passing.
- [x] All 23 original Phase 2 tests still pass.
- [x] Full `tests/unit/` suite: 313 passed (13 pre-existing fixture errors unrelated to this PR).
- [x] `ruff`, `black`, `mypy` all clean.
- [x] Manual smoke: `importlib.reload(llm_gateway)` keeps `_HAS_PROMETHEUS=True`.

## Verification

Three rounds of multi-agent review:
1. **Initial 5-critic review** of `30d3d2b` → 5/5 REQUEST CHANGES, surfaced 6 P1s + 7 P2/P3 issues.
2. **Fix-up agent** addressed all 6 P1s in atomic commits.
3. **3-critic verification** of fix-up commits → all ACCEPT, only mechanical `black` reformat needed (now `e60a0ef`).

## Follow-ups (filed, not blocking)

P2: #183 (INCR/EXPIRE atomicity), #184 (TTL rolling-reset semantics), #187 (email_classifier migration), #192 (admin endpoint + kill switch + alerting), #193 (Redis hygiene), #194 (work_history migration).

P3: #195 (short-response path test coverage + `LLMGenerationError` consumer).

## Risks called out

1. **`skip_fallback=True` semantic shift** in `_dispatch_provider_entry` — resume_generator no longer silently falls through to Ollama. Dashboards that assumed "cloud-fail-then-Ollama-succeed = cloud success" will see a different `provider_used` mix. **Intentional fix** per #186.
2. **`tailor_resume` now consults Redis breaker** — previously only in-process `@llm_circuit`. Operators may see new `circuit_open` outcomes for this path. **Intentional fix** per #189.
3. **`_scrub` scope is LLM-key-only** — doesn't cover GH PATs/Slack tokens. Out of scope; widen in a follow-up if any LLM error body ever quotes them.

https://claude.ai/code/session_01K7CXtKWcq3aiYmUEPMTJcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7CXtKWcq3aiYmUEPMTJcu)_