### PR TITLE
fix(P0): #89 + #90 combined — eliminate /auth/register takeover + close header-trust auth bypass

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -209,6 +209,31 @@ class Settings(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def require_clerk_url_in_production(self) -> Self:
+        """
+        Fail-fast guard against the auth bypass in issue #90.
+
+        ``get_current_user`` only runs RS256 JWKS validation when
+        ``CLERK_FRONTEND_API_URL`` is set. Without it, the backend silently
+        falls back to trusting the ``X-Clerk-User-Id`` header — a complete
+        auth bypass. Refuse to construct Settings in production so the
+        process crashes at boot, not on the first authenticated request.
+
+        Dev / staging / test environments are allowed to leave the URL
+        unset so local workflows (no Clerk tenant configured) keep working;
+        the auth dependency emits a one-shot warning in that case.
+        """
+        if self.is_production and not self.CLERK_FRONTEND_API_URL:
+            raise ValueError(
+                "CLERK_FRONTEND_API_URL must be set when ENVIRONMENT=production. "
+                "Without it, get_current_user trusts the X-Clerk-User-Id header from "
+                "any caller — a complete auth bypass. Set it to your Clerk Frontend "
+                "API URL, e.g. `fly secrets set "
+                "CLERK_FRONTEND_API_URL=https://your-app.clerk.accounts.dev`."
+            )
+        return self
+
     @property
     def is_production(self) -> bool:
         return self.ENVIRONMENT == "production"
@@ -216,6 +241,23 @@ class Settings(BaseSettings):
     @property
     def is_development(self) -> bool:
         return self.ENVIRONMENT == "development"
+
+    @property
+    def is_staging(self) -> bool:
+        return self.ENVIRONMENT == "staging"
+
+    @property
+    def clerk_jwt_enforced(self) -> bool:
+        """
+        True when the auth dependency must verify Clerk-issued JWTs.
+
+        Production deploys always enforce JWT verification — the config
+        validator above guarantees ``CLERK_FRONTEND_API_URL`` is set, so this
+        is effectively constant in production. Non-production environments
+        enforce JWT verification only when ``CLERK_FRONTEND_API_URL`` is
+        configured (e.g. staging pointed at a real Clerk tenant).
+        """
+        return self.is_production or bool(self.CLERK_FRONTEND_API_URL)
 
 
 @lru_cache

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -279,11 +279,13 @@ async def get_current_user(
     # Belt-and-braces for Issue #90: the config validator already refuses to
     # construct Settings without CLERK_FRONTEND_API_URL in production, but if
     # something monkey-patches the value at runtime we must NOT silently fall
-    # through to the X-Clerk-User-Id header bypass.
-    if settings.is_production and not settings.CLERK_FRONTEND_API_URL:
+    # through to the X-Clerk-User-Id header bypass. ``clerk_jwt_enforced``
+    # centralises the "JWT required" policy in app.config so the two
+    # defenses (this guard and the header-trust check below) cannot drift.
+    if settings.clerk_jwt_enforced and not settings.CLERK_FRONTEND_API_URL:
         logger.error(
-            "CLERK_FRONTEND_API_URL is unset in production — refusing request "
-            "to prevent X-Clerk-User-Id auth bypass (Issue #90)."
+            "CLERK_FRONTEND_API_URL is unset while clerk_jwt_enforced=True — "
+            "refusing request to prevent X-Clerk-User-Id auth bypass (Issue #90)."
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -328,10 +330,13 @@ async def get_current_user(
 
     # ── 2. Header path (extension / dev only) ────────────────────────────
     # The X-Clerk-User-Id header is a TRUSTED CLAIM with no cryptographic
-    # binding. In production the JWT path above is the only acceptable
-    # authentication mechanism — ignore the header outright to avoid any
-    # path that would resolve a user from an unverified header value.
-    if clerk_id is None and x_clerk_user_id and not settings.is_production:
+    # binding. Whenever JWT enforcement is on (any production deploy, or any
+    # non-production deploy that has CLERK_FRONTEND_API_URL set) the JWT
+    # path above is the only acceptable authentication mechanism — ignore
+    # the header outright. The check uses ``settings.clerk_jwt_enforced``
+    # so this policy lives in exactly one place (app.config) and the two
+    # defenses cannot drift.
+    if clerk_id is None and x_clerk_user_id and not settings.clerk_jwt_enforced:
         clerk_id = x_clerk_user_id
 
     if clerk_id:

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -249,32 +249,33 @@ async def _resolve_jwk_for_kid(kid: str) -> dict | None:
         return key
 
 
-async def get_current_user(
+async def _extract_clerk_id_from_credentials(
     request: Request,
-    db: AsyncSession = Depends(get_db),
-    x_clerk_user_id: str | None = Header(None, alias="X-Clerk-User-Id"),
-) -> "User":
+    x_clerk_user_id: str | None,
+) -> str | None:
     """
-    Resolve the authenticated user.
+    Extract the caller's ``clerk_id`` from validated credentials, without
+    touching the database.
 
     Priority:
     1. Production fail-closed (Issue #90): if ``CLERK_FRONTEND_API_URL`` is
-       missing in production, refuse the request with 401. The config
-       validator in ``app.config`` blocks process startup in this state, so
-       this branch is defense-in-depth for monkey-patched / mis-imported
-       settings.
+       missing while ``settings.clerk_jwt_enforced`` is True, refuse the
+       request with 401. The config validator in ``app.config`` blocks
+       process startup in this state, so this branch is defense-in-depth
+       for monkey-patched / mis-imported settings.
     2. If ``CLERK_FRONTEND_API_URL`` is configured: validate the
-       ``Authorization: Bearer <token>`` JWT against Clerk's JWKS.
-       In production the ``X-Clerk-User-Id`` header is NEVER trusted —
-       only the verified JWT subject becomes the resolved clerk_id.
-    3. Otherwise (dev / staging with no Clerk tenant) fall back to the
-       ``X-Clerk-User-Id`` header.
-    4. In development with no header: resolve the user whose ``clerk_id``
-       matches ``settings.DEV_TEST_USER_ID``. If that setting is empty,
-       return 401 (no credentials → unauthenticated).
-    """
-    from app.models.user import User  # late import to avoid circular deps
+       ``Authorization: Bearer <token>`` JWT against Clerk's JWKS and
+       return ``payload["sub"]``. The issuer is pinned to OUR Clerk tenant
+       to block tenant-confusion attacks.
+    3. Otherwise (dev / extension flow with no Clerk tenant): trust the
+       ``X-Clerk-User-Id`` header — but ONLY when JWT enforcement is OFF.
+       Whenever ``settings.clerk_jwt_enforced`` is True the header path is
+       skipped entirely (this is the P0 fix for Issue #90).
 
+    Returns ``None`` when no credentials are presented. Raises 401 if a JWT
+    is presented but fails verification — that path must never silently fall
+    through to the header.
+    """
     # ── 0. Production fail-closed guard ───────────────────────────────────
     # Belt-and-braces for Issue #90: the config validator already refuses to
     # construct Settings without CLERK_FRONTEND_API_URL in production, but if
@@ -331,7 +332,9 @@ async def get_current_user(
                     issuer=settings.CLERK_FRONTEND_API_URL,
                     options=options,
                 )
-                clerk_id = payload.get("sub")
+                sub = payload.get("sub")
+                if sub:
+                    clerk_id = sub
             except JOSEError as exc:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
@@ -346,8 +349,73 @@ async def get_current_user(
     # the header outright. The check uses ``settings.clerk_jwt_enforced``
     # so this policy lives in exactly one place (app.config) and the two
     # defenses cannot drift.
+    #
+    # Also: ``x_clerk_user_id`` is truthy for whitespace-only strings like
+    # ``"   "``; treat those as "no credentials" so they trigger the 401
+    # path in ``get_authenticated_clerk_id`` rather than passing as a
+    # valid clerk_id (which would 500 on the DB lookup or, worse, match a
+    # user whose clerk_id was accidentally stored with leading whitespace).
     if clerk_id is None and x_clerk_user_id and not settings.clerk_jwt_enforced:
-        clerk_id = x_clerk_user_id
+        stripped = x_clerk_user_id.strip()
+        if stripped:
+            clerk_id = stripped
+
+    return clerk_id
+
+
+async def get_authenticated_clerk_id(
+    request: Request,
+    x_clerk_user_id: str | None = Header(None, alias="X-Clerk-User-Id"),
+) -> str:
+    """
+    Resolve the caller's authenticated ``clerk_id`` without requiring an
+    existing ``User`` row.
+
+    Used by endpoints that must create the user record on first call
+    (e.g. ``POST /auth/register``). The ``clerk_id`` is taken from the
+    validated JWT (production) or ``X-Clerk-User-Id`` header (dev /
+    extension), NEVER from the request body — accepting a body-supplied
+    ``clerk_id`` would let any caller create or overwrite any user.
+
+    Raises 401 if no credentials are presented or the JWT fails verification.
+    """
+    clerk_id = await _extract_clerk_id_from_credentials(request, x_clerk_user_id)
+    if not clerk_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=(
+                "Authentication required. "
+                "Send Authorization: Bearer <token> from your Clerk session "
+                "(or X-Clerk-User-Id in dev/extension mode)."
+            ),
+        )
+    return clerk_id
+
+
+async def get_current_user(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    x_clerk_user_id: str | None = Header(None, alias="X-Clerk-User-Id"),
+) -> "User":
+    """
+    Resolve the authenticated user.
+
+    Priority:
+    1. Production fail-closed (Issue #90): if ``CLERK_FRONTEND_API_URL`` is
+       missing while JWT enforcement is on, refuse the request with 401.
+    2. If ``CLERK_FRONTEND_API_URL`` is configured: validate the
+       ``Authorization: Bearer <token>`` JWT against Clerk's JWKS.
+       In production the ``X-Clerk-User-Id`` header is NEVER trusted —
+       only the verified JWT subject becomes the resolved clerk_id.
+    3. Otherwise (dev / staging with no Clerk tenant) fall back to the
+       ``X-Clerk-User-Id`` header.
+    4. In development with no header: resolve the user whose ``clerk_id``
+       matches ``settings.DEV_TEST_USER_ID``. If that setting is empty,
+       return 401 (no credentials → unauthenticated).
+    """
+    from app.models.user import User  # late import to avoid circular deps
+
+    clerk_id = await _extract_clerk_id_from_credentials(request, x_clerk_user_id)
 
     if clerk_id:
         result = await db.execute(
@@ -395,7 +463,8 @@ async def get_current_user(
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail=(
-            "Authentication required. Send Authorization: Bearer <token> from your Clerk session."
+            "Authentication required. "
+            "Send Authorization: Bearer <token> from your Clerk session."
         ),
     )
 

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -313,12 +313,22 @@ async def get_current_user(
                         status_code=status.HTTP_401_UNAUTHORIZED,
                         detail="Invalid or expired authentication token.",
                     )
-                options = {"verify_aud": bool(settings.CLERK_JWT_AUDIENCE)}
+                # Pin the issuer to OUR Clerk tenant. Without ``verify_iss``,
+                # a token signed by a different Clerk tenant whose JWKS just
+                # happens to be served at the configured URL would pass — the
+                # ``kid`` and signature would check out and we'd resolve the
+                # foreign tenant's ``sub`` to a local user. Pinning the issuer
+                # closes that tenant-confusion vector.
+                options = {
+                    "verify_aud": bool(settings.CLERK_JWT_AUDIENCE),
+                    "verify_iss": True,
+                }
                 payload = jwt.decode(
                     token,
                     jwk,
                     algorithms=_CLERK_JWT_ALGORITHMS,
                     audience=settings.CLERK_JWT_AUDIENCE or None,
+                    issuer=settings.CLERK_FRONTEND_API_URL,
                     options=options,
                 )
                 clerk_id = payload.get("sub")

--- a/backend/app/dependencies.py
+++ b/backend/app/dependencies.py
@@ -55,6 +55,37 @@ _jwks_refresh_lock = asyncio.Lock()
 _CLERK_JWT_ALGORITHMS = ["RS256"]
 
 
+def _warn_if_clerk_url_missing() -> bool:
+    """
+    Emit a clear log warning when CLERK_FRONTEND_API_URL is unset in a
+    non-production environment (Issue #90).
+
+    Production deploys without the URL are already refused at startup by
+    the config validator in ``app.config`` — this helper exists for
+    dev / staging / test, where the documented header-bypass is still
+    permitted and we want it to be loud in CI logs.
+
+    Returns:
+        ``True`` if a warning was emitted (caller / tests can assert on
+        the return value without needing to capture log output, which is
+        fragile under loguru monkey-patching).
+    """
+    if not settings.CLERK_FRONTEND_API_URL and not settings.is_production:
+        logger.warning(
+            "CLERK_FRONTEND_API_URL is unset (env={}). JWT verification is "
+            "DISABLED and X-Clerk-User-Id will be trusted from any caller. "
+            "This is only safe for local development; production deploys "
+            "are refused at startup by app.config.",
+            settings.ENVIRONMENT,
+        )
+        return True
+    return False
+
+
+# Emit the warning at import time so it shows up in boot logs.
+_warn_if_clerk_url_missing()
+
+
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     """
     Provide a database session per request.
@@ -227,14 +258,37 @@ async def get_current_user(
     Resolve the authenticated user.
 
     Priority:
-    1. If CLERK_FRONTEND_API_URL is configured: validate the
+    1. Production fail-closed (Issue #90): if ``CLERK_FRONTEND_API_URL`` is
+       missing in production, refuse the request with 401. The config
+       validator in ``app.config`` blocks process startup in this state, so
+       this branch is defense-in-depth for monkey-patched / mis-imported
+       settings.
+    2. If ``CLERK_FRONTEND_API_URL`` is configured: validate the
        ``Authorization: Bearer <token>`` JWT against Clerk's JWKS.
-    2. Otherwise fall back to ``X-Clerk-User-Id`` header (dev / extension flow).
-    3. In development with no header: resolve the user whose ``clerk_id`` matches
-       ``settings.DEV_TEST_USER_ID``. If that setting is empty, return 401
-       (no credentials → unauthenticated).
+       In production the ``X-Clerk-User-Id`` header is NEVER trusted —
+       only the verified JWT subject becomes the resolved clerk_id.
+    3. Otherwise (dev / staging with no Clerk tenant) fall back to the
+       ``X-Clerk-User-Id`` header.
+    4. In development with no header: resolve the user whose ``clerk_id``
+       matches ``settings.DEV_TEST_USER_ID``. If that setting is empty,
+       return 401 (no credentials → unauthenticated).
     """
     from app.models.user import User  # late import to avoid circular deps
+
+    # ── 0. Production fail-closed guard ───────────────────────────────────
+    # Belt-and-braces for Issue #90: the config validator already refuses to
+    # construct Settings without CLERK_FRONTEND_API_URL in production, but if
+    # something monkey-patches the value at runtime we must NOT silently fall
+    # through to the X-Clerk-User-Id header bypass.
+    if settings.is_production and not settings.CLERK_FRONTEND_API_URL:
+        logger.error(
+            "CLERK_FRONTEND_API_URL is unset in production — refusing request "
+            "to prevent X-Clerk-User-Id auth bypass (Issue #90)."
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication unavailable: server misconfigured.",
+        )
 
     clerk_id: str | None = None
 
@@ -272,8 +326,12 @@ async def get_current_user(
                     detail="Invalid or expired authentication token.",
                 ) from exc
 
-    # ── 2. Header path (extension / dev) ─────────────────────────────────
-    if clerk_id is None and x_clerk_user_id:
+    # ── 2. Header path (extension / dev only) ────────────────────────────
+    # The X-Clerk-User-Id header is a TRUSTED CLAIM with no cryptographic
+    # binding. In production the JWT path above is the only acceptable
+    # authentication mechanism — ignore the header outright to avoid any
+    # path that would resolve a user from an unverified header value.
+    if clerk_id is None and x_clerk_user_id and not settings.is_production:
         clerk_id = x_clerk_user_id
 
     if clerk_id:
@@ -322,8 +380,7 @@ async def get_current_user(
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail=(
-            "Authentication required. "
-            "Send Authorization: Bearer <token> from your Clerk session."
+            "Authentication required. Send Authorization: Bearer <token> from your Clerk session."
         ),
     )
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -8,8 +8,9 @@ PATCH /api/v1/auth/me         → Update the authenticated user's profile
 
 import uuid
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_authenticated_clerk_id, get_current_user, get_db
@@ -61,7 +62,26 @@ async def register_user(
         total_applications_tracked=0,
     )
     db.add(user)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        # Race condition: a concurrent first-register call for the same
+        # ``clerk_id`` won the unique-index race. Roll back our failed
+        # insert, re-SELECT the row the winning request created, and
+        # respond idempotently with ``created=False`` instead of leaking
+        # a 500 to the second caller.
+        await db.rollback()
+        existing = await db.execute(select(User).where(User.clerk_id == clerk_id))
+        user = existing.scalar_one_or_none()
+        if user is None:
+            # Should be unreachable: the unique-key collision means a row
+            # for this clerk_id exists. If we genuinely cannot find it,
+            # surface a clean error rather than masking it as a 201.
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Registration conflict could not be resolved.",
+            )
+        return {"user_id": str(user.id), "created": False}
     await db.refresh(user)
     return {"user_id": str(user.id), "created": True}
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -12,33 +12,40 @@ from fastapi import APIRouter, Depends, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies import get_current_user, get_db
+from app.dependencies import get_authenticated_clerk_id, get_current_user, get_db
 from app.models.user import User
-from app.schemas.user import ProfileResponse, ProfileUpdate
+from app.schemas.user import ProfileResponse, ProfileUpdate, RegisterRequest
 
 router = APIRouter()
 
 
 @router.post("/register", status_code=status.HTTP_201_CREATED)
 async def register_user(
-    clerk_id: str,
-    email_hash: str,
-    github_username: str = "",
+    body: RegisterRequest,
+    clerk_id: str = Depends(get_authenticated_clerk_id),
     db: AsyncSession = Depends(get_db),
 ):
     """
-    Create or upsert a user record from a Clerk user ID.
+    Create or upsert a user record for the authenticated caller.
 
-    Called by the Clerk webhook (user.created event) or manually on first login.
-    Idempotent — safe to call multiple times for the same clerk_id.
+    SECURITY: ``clerk_id`` is derived server-side from the validated Clerk
+    JWT (or ``X-Clerk-User-Id`` header in dev / extension mode) — never
+    from the request body. Unauthenticated callers are rejected with 401
+    by the ``get_authenticated_clerk_id`` dependency, which blocks the
+    account-takeover vector where any caller could create or overwrite
+    any user record by supplying an arbitrary ``clerk_id``.
+
+    Called by the Clerk webhook proxy (user.created event) or by the
+    client on first login. Idempotent — safe to call multiple times for
+    the same authenticated identity.
     """
     existing = await db.execute(select(User).where(User.clerk_id == clerk_id))
     user = existing.scalar_one_or_none()
 
     if user:
         # Update mutable fields
-        if github_username:
-            user.github_username = github_username
+        if body.github_username:
+            user.github_username = body.github_username
         await db.commit()
         await db.refresh(user)
         return {"user_id": str(user.id), "created": False}
@@ -46,8 +53,8 @@ async def register_user(
     user = User(
         id=uuid.uuid4(),
         clerk_id=clerk_id,
-        email_hash=email_hash,
-        github_username=github_username or None,
+        email_hash=body.email_hash,
+        github_username=body.github_username or None,
         resume_repo_name="resume-vault",
         is_active=True,
         total_resumes_generated=0,

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -64,7 +64,7 @@ async def register_user(
     db.add(user)
     try:
         await db.commit()
-    except IntegrityError:
+    except IntegrityError as exc:
         # Race condition: a concurrent first-register call for the same
         # ``clerk_id`` won the unique-index race. Roll back our failed
         # insert, re-SELECT the row the winning request created, and
@@ -80,7 +80,7 @@ async def register_user(
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Registration conflict could not be resolved.",
-            )
+            ) from exc
         return {"user_id": str(user.id), "created": False}
     await db.refresh(user)
     return {"user_id": str(user.id), "created": True}

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -9,6 +9,7 @@ PATCH /api/v1/auth/me         → Update the authenticated user's profile
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
+from loguru import logger
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,6 +19,12 @@ from app.models.user import User
 from app.schemas.user import ProfileResponse, ProfileUpdate, RegisterRequest
 
 router = APIRouter()
+
+# PostgreSQL SQLSTATE for unique_violation. We narrow the IntegrityError
+# race-recovery branch to this code so a NOT-NULL / CHECK / FK violation
+# (which indicates a real bug, not a concurrent insert) surfaces as a clean
+# 500 instead of being swallowed by the "re-SELECT the winning row" path.
+_PG_UNIQUE_VIOLATION = "23505"
 
 
 @router.post("/register", status_code=status.HTTP_201_CREATED)
@@ -65,22 +72,46 @@ async def register_user(
     try:
         await db.commit()
     except IntegrityError as exc:
-        # Race condition: a concurrent first-register call for the same
-        # ``clerk_id`` won the unique-index race. Roll back our failed
-        # insert, re-SELECT the row the winning request created, and
-        # respond idempotently with ``created=False`` instead of leaking
-        # a 500 to the second caller.
+        # Narrow recovery to PostgreSQL's unique_violation (SQLSTATE 23505).
+        # A broader ``except IntegrityError`` would also swallow NOT-NULL /
+        # FK / CHECK violations — those indicate a real bug (or schema
+        # drift), not a concurrent first-register race, and must surface as
+        # a 500 with the original cause logged so we can debug them.
         await db.rollback()
+        pgcode = getattr(getattr(exc, "orig", None), "pgcode", None)
+        if pgcode != _PG_UNIQUE_VIOLATION:
+            logger.exception(
+                "Unexpected IntegrityError in /auth/register: pgcode={} " "clerk_id_prefix={}",
+                pgcode,
+                clerk_id[:8] if clerk_id else None,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Registration failed due to database constraint.",
+            ) from exc
+
+        # Race condition: a concurrent first-register call for the same
+        # ``clerk_id`` won the unique-index race. Re-SELECT the row the
+        # winning request created and respond idempotently with
+        # ``created=False`` instead of leaking a 500 to the second caller.
         existing = await db.execute(select(User).where(User.clerk_id == clerk_id))
         user = existing.scalar_one_or_none()
         if user is None:
             # Should be unreachable: the unique-key collision means a row
             # for this clerk_id exists. If we genuinely cannot find it,
             # surface a clean error rather than masking it as a 201.
+            logger.error(
+                "IntegrityError 23505 on /auth/register but no row found for " "clerk_id_prefix={}",
+                clerk_id[:8] if clerk_id else None,
+            )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Registration conflict could not be resolved.",
             ) from exc
+        logger.warning(
+            "Concurrent /auth/register race resolved idempotently for " "clerk_id_prefix={}",
+            clerk_id[:8] if clerk_id else None,
+        )
         return {"user_id": str(user.id), "created": False}
     await db.refresh(user)
     return {"user_id": str(user.id), "created": True}

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -23,6 +23,26 @@ class UserCreate(BaseModel):
     email: str = Field(..., description="Used only for hashing, never stored raw")
 
 
+class RegisterRequest(BaseModel):
+    """
+    Body for POST /api/v1/auth/register.
+
+    SECURITY: ``clerk_id`` is intentionally NOT part of this schema. It is
+    derived server-side from the validated Clerk JWT (or the
+    ``X-Clerk-User-Id`` header in dev / extension mode) — never from the
+    request body. Accepting a body-supplied ``clerk_id`` would allow any
+    unauthenticated caller to create or overwrite any user.
+
+    ``model_config`` forbids unknown fields, so a stray ``clerk_id`` key
+    in the body is rejected with 422 rather than silently ignored.
+    """
+
+    email_hash: str = Field(..., min_length=1, max_length=128)
+    github_username: str = Field(default="", max_length=255)
+
+    model_config = {"extra": "forbid"}
+
+
 class UserSetupGitHub(BaseModel):
     """Schema for connecting GitHub account."""
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -37,7 +37,18 @@ class RegisterRequest(BaseModel):
     in the body is rejected with 422 rather than silently ignored.
     """
 
-    email_hash: str = Field(..., min_length=1, max_length=128)
+    # ``email_hash`` is a SHA-256 hex digest: exactly 64 lowercase hex chars.
+    # The DB column is ``String(64)`` — bounding both ends here prevents a
+    # 65-128 char value from passing Pydantic and then failing the DB write
+    # with a 500. The hex regex also rules out non-hex payloads (which would
+    # never collide with a real digest anyway).
+    email_hash: str = Field(
+        ...,
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+        description="SHA-256 hex digest of the user's email (64 hex chars).",
+    )
     github_username: str = Field(default="", max_length=255)
 
     model_config = {"extra": "forbid"}

--- a/backend/tests/test_auth_dev_fallback.py
+++ b/backend/tests/test_auth_dev_fallback.py
@@ -44,8 +44,17 @@ def test_settings_allows_dev_test_user_id_in_development():
 
 
 def test_settings_allows_empty_dev_test_user_id_in_production():
-    """ENVIRONMENT=production with empty DEV_TEST_USER_ID must validate cleanly."""
-    s = Settings(ENVIRONMENT="production", DEV_TEST_USER_ID="")
+    """ENVIRONMENT=production with empty DEV_TEST_USER_ID must validate cleanly.
+
+    Issue #90 added an unrelated production guard that requires
+    CLERK_FRONTEND_API_URL — supply a dummy value so this test isolates the
+    DEV_TEST_USER_ID code path.
+    """
+    s = Settings(
+        ENVIRONMENT="production",
+        DEV_TEST_USER_ID="",
+        CLERK_FRONTEND_API_URL="https://clerk.example.com",
+    )
     assert s.DEV_TEST_USER_ID == ""
     assert s.is_production is True
 

--- a/backend/tests/test_auth_register.py
+++ b/backend/tests/test_auth_register.py
@@ -169,17 +169,45 @@ def test_register_request_schema_forbids_clerk_id():
     from pydantic import ValidationError
 
     # Sanity: minimal valid payload constructs.
-    valid = RegisterRequest(email_hash="x" * 64)
-    assert valid.email_hash == "x" * 64
+    valid = RegisterRequest(email_hash="0" * 64)
+    assert valid.email_hash == "0" * 64
     assert valid.github_username == ""
 
     # ``clerk_id`` must be rejected.
     with pytest.raises(ValidationError) as exc_info:
-        RegisterRequest(email_hash="x" * 64, clerk_id="clerk_should_be_forbidden")
+        RegisterRequest(email_hash="0" * 64, clerk_id="clerk_should_be_forbidden")
     assert "clerk_id" in str(exc_info.value)
 
     # And ``clerk_id`` is not even a declared field on the model.
     assert "clerk_id" not in RegisterRequest.model_fields
+
+
+def test_register_request_email_hash_must_be_sha256_hex():
+    """``email_hash`` must be exactly 64 hex chars — the DB column is
+    ``String(64)`` and the field is a SHA-256 hex digest.
+
+    Regression guard: previously the schema allowed up to 128 chars, so a
+    65-128 char value would pass Pydantic and then 500 on the DB write.
+    """
+    from pydantic import ValidationError
+
+    # 64 hex chars → accepted.
+    RegisterRequest(email_hash="a" * 64)
+    RegisterRequest(email_hash="0123456789abcdef" * 4)
+
+    # Too short → rejected.
+    with pytest.raises(ValidationError):
+        RegisterRequest(email_hash="a" * 63)
+
+    # Too long (the old upper bound, exceeds the DB column) → rejected.
+    with pytest.raises(ValidationError):
+        RegisterRequest(email_hash="a" * 65)
+    with pytest.raises(ValidationError):
+        RegisterRequest(email_hash="a" * 128)
+
+    # Non-hex chars → rejected (``g`` is not a hex digit).
+    with pytest.raises(ValidationError):
+        RegisterRequest(email_hash="g" * 64)
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +294,7 @@ async def test_register_user_creates_new_user_when_clerk_id_unknown():
 
     db.refresh = AsyncMock(side_effect=_refresh)
 
-    body = RegisterRequest(email_hash="h" * 64, github_username="octocat")
+    body = RegisterRequest(email_hash="d" * 64, github_username="octocat")
     result = await register_user(
         body=body,
         clerk_id="clerk_new_caller",
@@ -282,7 +310,7 @@ async def test_register_user_creates_new_user_when_clerk_id_unknown():
     new_user = captured_user["obj"]
     assert isinstance(new_user, User)
     assert new_user.clerk_id == "clerk_new_caller"
-    assert new_user.email_hash == "h" * 64
+    assert new_user.email_hash == "d" * 64
     assert new_user.github_username == "octocat"
     assert new_user.is_active is True
 
@@ -297,7 +325,7 @@ async def test_register_user_is_idempotent_for_existing_clerk_id():
     existing = User(
         id=uuid.uuid4(),
         clerk_id="clerk_existing",
-        email_hash="i" * 64,
+        email_hash="c" * 64,
         github_username="old_handle",
         resume_repo_name="resume-vault",
         is_active=True,
@@ -311,7 +339,7 @@ async def test_register_user_is_idempotent_for_existing_clerk_id():
     db.commit = AsyncMock()
     db.refresh = AsyncMock()
 
-    body = RegisterRequest(email_hash="i" * 64, github_username="new_handle")
+    body = RegisterRequest(email_hash="c" * 64, github_username="new_handle")
     result = await register_user(
         body=body,
         clerk_id="clerk_existing",
@@ -345,12 +373,12 @@ async def test_register_user_ignores_clerk_id_attempted_via_body_overload():
     db.commit = AsyncMock()
     db.refresh = AsyncMock()
 
-    body = RegisterRequest(email_hash="j" * 64)
+    body = RegisterRequest(email_hash="f" * 64)
     # Pydantic v2 ``extra='forbid'`` rejects this at construction. Verify that:
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        RegisterRequest(email_hash="j" * 64, clerk_id="clerk_smuggled")
+        RegisterRequest(email_hash="f" * 64, clerk_id="clerk_smuggled")
 
     # And even if a downstream caller attaches the attribute post-hoc, the
     # route code never reads it — it only references ``body.email_hash`` and

--- a/backend/tests/test_auth_register.py
+++ b/backend/tests/test_auth_register.py
@@ -1,0 +1,368 @@
+"""
+Tests for POST /api/v1/auth/register — Issue #89.
+
+SECURITY CONTEXT
+----------------
+The original endpoint accepted ``clerk_id`` as a body parameter with NO
+authentication: any unauthenticated caller could create or overwrite any
+user record by posting an arbitrary ``clerk_id``. That is a direct account
+takeover vector.
+
+The fix:
+  * ``clerk_id`` is taken from the validated JWT or ``X-Clerk-User-Id``
+    header via the ``get_authenticated_clerk_id`` dependency.
+  * ``clerk_id`` is removed from the request body schema entirely.
+  * Unauthenticated requests are rejected with 401.
+  * The ``RegisterRequest`` schema sets ``extra='forbid'`` so a stray
+    ``clerk_id`` key in the body is rejected (422) rather than silently
+    ignored.
+
+This module mixes:
+
+* HTTP-level integration checks via the ``client`` fixture for the
+  unauthenticated rejection and body-validation paths (no DB writes, so
+  they cooperate with the transactional ``db_session`` fixture used by
+  the rest of the test suite).
+* Unit-level checks on the route handler and dependency to lock in the
+  happy path / idempotent upsert without fighting the test-DB
+  transaction wrapper.
+* A pure schema test that pins ``clerk_id`` out of ``RegisterRequest``
+  for all time.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.models.user import User
+from app.routers.auth import register_user
+from app.schemas.user import RegisterRequest
+
+# ---------------------------------------------------------------------------
+# HTTP: 401 — unauthenticated requests must be rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_without_clerk_header_returns_401(
+    client: AsyncClient, db_session, monkeypatch
+):
+    """POST /auth/register with no X-Clerk-User-Id and no JWT must return 401.
+
+    Critical regression test for the account-takeover vector described in #89.
+    No User row may be created when the caller is unauthenticated.
+    """
+    # Ensure the JWT path is disabled so the test isolates the header path.
+    from app.dependencies import settings
+
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={"email_hash": "a" * 64, "github_username": "attacker"},
+    )
+
+    assert response.status_code == 401, response.text
+
+    # And no user row was created as a side effect of the rejected request.
+    result = await db_session.execute(select(User))
+    assert result.scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_register_with_empty_clerk_header_returns_401(
+    client: AsyncClient, monkeypatch
+):
+    """An empty X-Clerk-User-Id header must be treated the same as a missing
+    one — 401 (FastAPI treats an empty header value as ``None``)."""
+    from app.dependencies import settings
+
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={"email_hash": "a" * 64},
+        headers={"X-Clerk-User-Id": ""},
+    )
+
+    assert response.status_code == 401, response.text
+
+
+# ---------------------------------------------------------------------------
+# HTTP: body validation — clerk_id and other unknown fields are rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_clerk_id_in_body(
+    client: AsyncClient, db_session, monkeypatch
+):
+    """A body containing ``clerk_id`` must be rejected — ``RegisterRequest``
+    has ``extra='forbid'``, so FastAPI returns 422.
+
+    This guards against an attacker trying to override the authenticated
+    identity by re-introducing the legacy body field, AND against a future
+    refactor that re-adds ``clerk_id`` as a declared field.
+    """
+    from app.dependencies import settings
+
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    auth_clerk = "clerk_authenticated_caller"
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "clerk_id": "clerk_victim_account",  # attempt to hijack
+            "email_hash": "b" * 64,
+            "github_username": "attacker",
+        },
+        headers={"X-Clerk-User-Id": auth_clerk},
+    )
+
+    # 422 because the schema forbids extra fields.
+    assert response.status_code == 422, response.text
+
+    # Crucially, no row was created for the victim.
+    result = await db_session.execute(
+        select(User).where(User.clerk_id == "clerk_victim_account")
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_unknown_body_fields(
+    client: AsyncClient, monkeypatch
+):
+    """Any unknown body field (other than ``clerk_id``) must also be rejected
+    by ``extra='forbid'`` — broader regression hedge against schema drift."""
+    from app.dependencies import settings
+
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={
+            "email_hash": "e" * 64,
+            "is_admin": True,  # not in schema
+        },
+        headers={"X-Clerk-User-Id": "clerk_unknown_field"},
+    )
+    assert response.status_code == 422, response.text
+
+
+# ---------------------------------------------------------------------------
+# Schema-level lock: clerk_id can never be a body field
+# ---------------------------------------------------------------------------
+
+
+def test_register_request_schema_forbids_clerk_id():
+    """``RegisterRequest`` must not accept ``clerk_id`` — extra='forbid'.
+
+    Pure unit check: no DB, no HTTP. This locks the schema contract so a
+    future refactor cannot accidentally re-introduce the field.
+    """
+    from pydantic import ValidationError
+
+    # Sanity: minimal valid payload constructs.
+    valid = RegisterRequest(email_hash="x" * 64)
+    assert valid.email_hash == "x" * 64
+    assert valid.github_username == ""
+
+    # ``clerk_id`` must be rejected.
+    with pytest.raises(ValidationError) as exc_info:
+        RegisterRequest(email_hash="x" * 64, clerk_id="clerk_should_be_forbidden")
+    assert "clerk_id" in str(exc_info.value)
+
+    # And ``clerk_id`` is not even a declared field on the model.
+    assert "clerk_id" not in RegisterRequest.model_fields
+
+
+# ---------------------------------------------------------------------------
+# Unit: get_authenticated_clerk_id rejects unauthenticated callers
+# ---------------------------------------------------------------------------
+
+
+def _request_without_auth():
+    from fastapi import Request
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/auth/register",
+        "headers": [],
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_clerk_id_raises_401_when_no_credentials(monkeypatch):
+    """The dependency that backs ``POST /auth/register`` must raise 401 when
+    no JWT and no header are presented — even outside ``get_current_user``."""
+    from fastapi import HTTPException
+
+    from app.dependencies import get_authenticated_clerk_id, settings
+
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_authenticated_clerk_id(
+            request=_request_without_auth(),
+            x_clerk_user_id=None,
+        )
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_clerk_id_returns_header_value(monkeypatch):
+    """With the header set and no JWT configured, the dependency returns the header."""
+    from app.dependencies import get_authenticated_clerk_id, settings
+
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    clerk = await get_authenticated_clerk_id(
+        request=_request_without_auth(),
+        x_clerk_user_id="clerk_from_header_xyz",
+    )
+    assert clerk == "clerk_from_header_xyz"
+
+
+# ---------------------------------------------------------------------------
+# Unit: register_user happy path (mocked DB, no transaction fixture friction)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+@pytest.mark.asyncio
+async def test_register_user_creates_new_user_when_clerk_id_unknown():
+    """Direct call to the route handler with an authenticated clerk_id and
+    an unknown user creates a new ``User`` row keyed on that clerk_id."""
+    captured_user: dict = {}
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_FakeResult(None))
+
+    def _add(obj):
+        captured_user["obj"] = obj
+
+    db.add = MagicMock(side_effect=_add)
+    db.commit = AsyncMock()
+
+    async def _refresh(obj):
+        # Simulate the post-flush refresh assigning the same id.
+        return None
+
+    db.refresh = AsyncMock(side_effect=_refresh)
+
+    body = RegisterRequest(email_hash="h" * 64, github_username="octocat")
+    result = await register_user(
+        body=body,
+        clerk_id="clerk_new_caller",
+        db=db,
+    )
+
+    # Response shape
+    assert result["created"] is True
+    assert isinstance(result["user_id"], str)
+    uuid.UUID(result["user_id"])  # well-formed UUID
+
+    # The added object uses the AUTHENTICATED clerk_id, not anything from the body.
+    new_user = captured_user["obj"]
+    assert isinstance(new_user, User)
+    assert new_user.clerk_id == "clerk_new_caller"
+    assert new_user.email_hash == "h" * 64
+    assert new_user.github_username == "octocat"
+    assert new_user.is_active is True
+
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_register_user_is_idempotent_for_existing_clerk_id():
+    """If a user already exists for the authenticated clerk_id, the route is
+    idempotent: ``created=False`` and the existing row's mutable fields are
+    updated."""
+    existing = User(
+        id=uuid.uuid4(),
+        clerk_id="clerk_existing",
+        email_hash="i" * 64,
+        github_username="old_handle",
+        resume_repo_name="resume-vault",
+        is_active=True,
+        total_resumes_generated=0,
+        total_applications_tracked=0,
+    )
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_FakeResult(existing))
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    body = RegisterRequest(email_hash="i" * 64, github_username="new_handle")
+    result = await register_user(
+        body=body,
+        clerk_id="clerk_existing",
+        db=db,
+    )
+
+    assert result["created"] is False
+    assert result["user_id"] == str(existing.id)
+    # github_username is the one mutable field updated on idempotent calls.
+    assert existing.github_username == "new_handle"
+    # No NEW row was added.
+    db.add.assert_not_called()
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_register_user_ignores_clerk_id_attempted_via_body_overload():
+    """Even if someone monkey-patches ``RegisterRequest`` to smuggle a
+    ``clerk_id`` attribute, the route MUST use the authenticated dependency
+    value — never read ``clerk_id`` off the body.
+
+    We assert this by attaching a stray ``clerk_id`` attribute to a valid
+    body and confirming the new user is created under the dependency-supplied
+    ``clerk_id`` (not the smuggled one).
+    """
+    captured_user: dict = {}
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_FakeResult(None))
+    db.add = MagicMock(side_effect=lambda obj: captured_user.update({"obj": obj}))
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    body = RegisterRequest(email_hash="j" * 64)
+    # Pydantic v2 ``extra='forbid'`` rejects this at construction. Verify that:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        RegisterRequest(email_hash="j" * 64, clerk_id="clerk_smuggled")
+
+    # And even if a downstream caller attaches the attribute post-hoc, the
+    # route code never reads it — it only references ``body.email_hash`` and
+    # ``body.github_username``. We exercise the route to confirm.
+    object.__setattr__(body, "clerk_id", "clerk_smuggled")  # bypass pydantic
+
+    await register_user(
+        body=body,
+        clerk_id="clerk_authenticated",
+        db=db,
+    )
+
+    new_user = captured_user["obj"]
+    assert new_user.clerk_id == "clerk_authenticated"
+    assert new_user.clerk_id != "clerk_smuggled"

--- a/backend/tests/test_auth_register.py
+++ b/backend/tests/test_auth_register.py
@@ -394,3 +394,93 @@ async def test_register_user_ignores_clerk_id_attempted_via_body_overload():
     new_user = captured_user["obj"]
     assert new_user.clerk_id == "clerk_authenticated"
     assert new_user.clerk_id != "clerk_smuggled"
+
+
+# ---------------------------------------------------------------------------
+# Unit: register_user is race-safe against concurrent first-register calls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_user_handles_concurrent_insert_race():
+    """When two concurrent first-register calls for the same ``clerk_id``
+    both see NULL on the initial SELECT, the loser's INSERT raises
+    ``IntegrityError`` on the unique constraint. The route must catch
+    it, re-SELECT, and return an idempotent ``created=False`` response —
+    not bubble a 500.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    winner = User(
+        id=uuid.uuid4(),
+        clerk_id="clerk_race",
+        email_hash="a" * 64,
+        github_username=None,
+        resume_repo_name="resume-vault",
+        is_active=True,
+        total_resumes_generated=0,
+        total_applications_tracked=0,
+    )
+
+    # First SELECT (pre-insert) → NULL (we don't see the winner yet).
+    # commit() raises IntegrityError (winner already committed).
+    # Second SELECT (post-rollback) → winner row.
+    execute_calls = {"n": 0}
+
+    async def _execute(_stmt):
+        execute_calls["n"] += 1
+        if execute_calls["n"] == 1:
+            return _FakeResult(None)
+        return _FakeResult(winner)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    db.add = MagicMock()
+    db.commit = AsyncMock(
+        side_effect=IntegrityError("INSERT", params=None, orig=Exception("duplicate key"))
+    )
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+
+    body = RegisterRequest(email_hash="a" * 64)
+    result = await register_user(
+        body=body,
+        clerk_id="clerk_race",
+        db=db,
+    )
+
+    # Idempotent response: the loser saw the winner's row.
+    assert result["created"] is False
+    assert result["user_id"] == str(winner.id)
+    # We rolled back the failed insert before re-SELECTing.
+    db.rollback.assert_awaited_once()
+    # Two SELECTs total: one before insert, one after rollback.
+    assert execute_calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_register_user_500s_if_integrity_error_without_recoverable_row():
+    """Defensive: if commit raises IntegrityError but the post-rollback
+    SELECT still returns NULL (should be unreachable), the route returns
+    500 rather than silently fabricating a fake idempotent response."""
+    from sqlalchemy.exc import IntegrityError
+
+    from fastapi import HTTPException
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_FakeResult(None))  # always NULL
+    db.add = MagicMock()
+    db.commit = AsyncMock(
+        side_effect=IntegrityError("INSERT", params=None, orig=Exception("dup"))
+    )
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+
+    body = RegisterRequest(email_hash="a" * 64)
+    with pytest.raises(HTTPException) as exc_info:
+        await register_user(
+            body=body,
+            clerk_id="clerk_phantom",
+            db=db,
+        )
+    assert exc_info.value.status_code == 500

--- a/backend/tests/test_auth_register.py
+++ b/backend/tests/test_auth_register.py
@@ -260,6 +260,44 @@ async def test_get_authenticated_clerk_id_returns_header_value(monkeypatch):
     assert clerk == "clerk_from_header_xyz"
 
 
+@pytest.mark.asyncio
+async def test_get_authenticated_clerk_id_rejects_whitespace_only_header(monkeypatch):
+    """A whitespace-only ``X-Clerk-User-Id`` header is truthy in Python but
+    is not a valid identity. The dependency must reject it with 401 — not
+    pass ``"   "`` through to the DB lookup.
+    """
+    from fastapi import HTTPException
+
+    from app.dependencies import get_authenticated_clerk_id, settings
+
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    for blank in ("   ", "\t", "\n", " \t \n "):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_authenticated_clerk_id(
+                request=_request_without_auth(),
+                x_clerk_user_id=blank,
+            )
+        assert exc_info.value.status_code == 401, f"expected 401 for {blank!r}"
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_clerk_id_strips_surrounding_whitespace(monkeypatch):
+    """A header padded with whitespace (e.g. from a stray newline in a curl
+    header file) should resolve to the trimmed clerk_id, not the padded
+    value — otherwise the DB lookup would fail to match the stored id.
+    """
+    from app.dependencies import get_authenticated_clerk_id, settings
+
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    clerk = await get_authenticated_clerk_id(
+        request=_request_without_auth(),
+        x_clerk_user_id="  clerk_padded  ",
+    )
+    assert clerk == "clerk_padded"
+
+
 # ---------------------------------------------------------------------------
 # Unit: register_user happy path (mocked DB, no transaction fixture friction)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_auth_register.py
+++ b/backend/tests/test_auth_register.py
@@ -75,9 +75,7 @@ async def test_register_without_clerk_header_returns_401(
 
 
 @pytest.mark.asyncio
-async def test_register_with_empty_clerk_header_returns_401(
-    client: AsyncClient, monkeypatch
-):
+async def test_register_with_empty_clerk_header_returns_401(client: AsyncClient, monkeypatch):
     """An empty X-Clerk-User-Id header must be treated the same as a missing
     one — 401 (FastAPI treats an empty header value as ``None``)."""
     from app.dependencies import settings
@@ -99,9 +97,7 @@ async def test_register_with_empty_clerk_header_returns_401(
 
 
 @pytest.mark.asyncio
-async def test_register_rejects_clerk_id_in_body(
-    client: AsyncClient, db_session, monkeypatch
-):
+async def test_register_rejects_clerk_id_in_body(client: AsyncClient, db_session, monkeypatch):
     """A body containing ``clerk_id`` must be rejected — ``RegisterRequest``
     has ``extra='forbid'``, so FastAPI returns 422.
 
@@ -128,16 +124,12 @@ async def test_register_rejects_clerk_id_in_body(
     assert response.status_code == 422, response.text
 
     # Crucially, no row was created for the victim.
-    result = await db_session.execute(
-        select(User).where(User.clerk_id == "clerk_victim_account")
-    )
+    result = await db_session.execute(select(User).where(User.clerk_id == "clerk_victim_account"))
     assert result.scalar_one_or_none() is None
 
 
 @pytest.mark.asyncio
-async def test_register_rejects_unknown_body_fields(
-    client: AsyncClient, monkeypatch
-):
+async def test_register_rejects_unknown_body_fields(client: AsyncClient, monkeypatch):
     """Any unknown body field (other than ``clerk_id``) must also be rejected
     by ``extra='forbid'`` — broader regression hedge against schema drift."""
     from app.dependencies import settings
@@ -508,9 +500,7 @@ async def test_register_user_500s_if_integrity_error_without_recoverable_row():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_FakeResult(None))  # always NULL
     db.add = MagicMock()
-    db.commit = AsyncMock(
-        side_effect=IntegrityError("INSERT", params=None, orig=Exception("dup"))
-    )
+    db.commit = AsyncMock(side_effect=IntegrityError("INSERT", params=None, orig=Exception("dup")))
     db.rollback = AsyncMock()
     db.refresh = AsyncMock()
 

--- a/backend/tests/test_auth_register.py
+++ b/backend/tests/test_auth_register.py
@@ -431,13 +431,33 @@ async def test_register_user_ignores_clerk_id_attempted_via_body_overload():
 # ---------------------------------------------------------------------------
 
 
+def _unique_violation_orig():
+    """Build an ``orig`` exception that mimics psycopg's ``UniqueViolation``
+    well enough for the route's narrowed handler (``pgcode == "23505"``).
+
+    Using ``types.SimpleNamespace`` keeps the test fixture independent of
+    whichever DBAPI driver the project ships with — we only need the
+    attribute the route reads."""
+    import types
+
+    return types.SimpleNamespace(pgcode="23505")
+
+
+def _not_null_violation_orig():
+    """Mimic psycopg's ``NotNullViolation`` (SQLSTATE 23502). The route
+    must classify this as a real bug and 500, not as a race recovery."""
+    import types
+
+    return types.SimpleNamespace(pgcode="23502")
+
+
 @pytest.mark.asyncio
 async def test_register_user_handles_concurrent_insert_race():
     """When two concurrent first-register calls for the same ``clerk_id``
     both see NULL on the initial SELECT, the loser's INSERT raises
-    ``IntegrityError`` on the unique constraint. The route must catch
-    it, re-SELECT, and return an idempotent ``created=False`` response —
-    not bubble a 500.
+    ``IntegrityError`` on the unique constraint (pgcode 23505). The route
+    must catch it, re-SELECT, and return an idempotent ``created=False``
+    response — not bubble a 500.
     """
     from sqlalchemy.exc import IntegrityError
 
@@ -467,7 +487,7 @@ async def test_register_user_handles_concurrent_insert_race():
     db.execute = AsyncMock(side_effect=_execute)
     db.add = MagicMock()
     db.commit = AsyncMock(
-        side_effect=IntegrityError("INSERT", params=None, orig=Exception("duplicate key"))
+        side_effect=IntegrityError("INSERT", params=None, orig=_unique_violation_orig())
     )
     db.rollback = AsyncMock()
     db.refresh = AsyncMock()
@@ -490,16 +510,19 @@ async def test_register_user_handles_concurrent_insert_race():
 
 @pytest.mark.asyncio
 async def test_register_user_500s_if_integrity_error_without_recoverable_row():
-    """Defensive: if commit raises IntegrityError but the post-rollback
-    SELECT still returns NULL (should be unreachable), the route returns
-    500 rather than silently fabricating a fake idempotent response."""
+    """Defensive: if commit raises IntegrityError with pgcode 23505 but the
+    post-rollback SELECT still returns NULL (should be unreachable), the
+    route returns 500 rather than silently fabricating a fake idempotent
+    response."""
     from fastapi import HTTPException
     from sqlalchemy.exc import IntegrityError
 
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_FakeResult(None))  # always NULL
     db.add = MagicMock()
-    db.commit = AsyncMock(side_effect=IntegrityError("INSERT", params=None, orig=Exception("dup")))
+    db.commit = AsyncMock(
+        side_effect=IntegrityError("INSERT", params=None, orig=_unique_violation_orig())
+    )
     db.rollback = AsyncMock()
     db.refresh = AsyncMock()
 
@@ -511,3 +534,85 @@ async def test_register_user_500s_if_integrity_error_without_recoverable_row():
             db=db,
         )
     assert exc_info.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_register_user_500s_on_non_unique_integrity_error():
+    """A non-unique IntegrityError (e.g. NOT NULL, FK, CHECK violation)
+    must NOT be silently absorbed by the race-recovery branch — those
+    indicate real schema bugs and must surface as a 500 with the original
+    exception chained.
+
+    This pins the narrowing of the ``except IntegrityError`` block from
+    Round 3: an earlier overly-broad catch would re-SELECT and mask the
+    bug as a successful idempotent response (if any row happened to
+    exist) or as a misleading "conflict could not be resolved" 500 with
+    the wrong detail string.
+    """
+    from fastapi import HTTPException
+    from sqlalchemy.exc import IntegrityError
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_FakeResult(None))
+    db.add = MagicMock()
+    db.commit = AsyncMock(
+        side_effect=IntegrityError("INSERT", params=None, orig=_not_null_violation_orig())
+    )
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+
+    body = RegisterRequest(email_hash="a" * 64)
+    with pytest.raises(HTTPException) as exc_info:
+        await register_user(
+            body=body,
+            clerk_id="clerk_schema_bug",
+            db=db,
+        )
+
+    assert exc_info.value.status_code == 500
+    # The detail string distinguishes a schema bug from the
+    # "conflict could not be resolved" race-path detail, so operators
+    # can grep production logs / responses to triage.
+    assert exc_info.value.detail == "Registration failed due to database constraint."
+    # We still rolled back so the session is clean for the next request.
+    db.rollback.assert_awaited_once()
+    # Crucially, the route must NOT have re-SELECTed for the winning row —
+    # that branch is reserved for 23505. Only the initial pre-insert SELECT
+    # happened.
+    assert db.execute.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Unit: production header-bypass is closed even on /auth/register
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_header_only_auth_in_production(monkeypatch):
+    """Round 3 / Critic 2 regression: when ``CLERK_FRONTEND_API_URL`` is set
+    (production posture), a request that presents ONLY the ``X-Clerk-User-Id``
+    header (no ``Authorization: Bearer`` JWT) MUST be rejected with 401.
+
+    The header is a trusted claim with no cryptographic binding — honouring
+    it in production would re-open exactly the auth-bypass vector Issue #90
+    closes. ``get_authenticated_clerk_id`` backs ``POST /auth/register``, so
+    this also closes the original #89 takeover vector on the production
+    posture.
+    """
+    from fastapi import HTTPException
+
+    from app.dependencies import get_authenticated_clerk_id, settings
+
+    # Production posture: URL is set, so ``settings.clerk_jwt_enforced`` is True.
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "https://clerk.example.com")
+    assert settings.clerk_jwt_enforced is True
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_authenticated_clerk_id(
+            request=_request_without_auth(),
+            x_clerk_user_id="user_attacker_supplied",
+        )
+    assert exc_info.value.status_code == 401
+    # The attacker-supplied identity must never appear in the error detail.
+    assert "user_attacker_supplied" not in exc_info.value.detail

--- a/backend/tests/test_auth_register.py
+++ b/backend/tests/test_auth_register.py
@@ -493,9 +493,8 @@ async def test_register_user_500s_if_integrity_error_without_recoverable_row():
     """Defensive: if commit raises IntegrityError but the post-rollback
     SELECT still returns NULL (should be unreachable), the route returns
     500 rather than silently fabricating a fake idempotent response."""
-    from sqlalchemy.exc import IntegrityError
-
     from fastapi import HTTPException
+    from sqlalchemy.exc import IntegrityError
 
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_FakeResult(None))  # always NULL

--- a/backend/tests/test_clerk_url_required_in_production.py
+++ b/backend/tests/test_clerk_url_required_in_production.py
@@ -463,3 +463,54 @@ async def test_production_jwt_takes_precedence_over_header(
     )
     assert header_sub not in captured_clerk_ids
     assert user.clerk_id == jwt_sub
+
+
+@pytest.mark.asyncio
+async def test_production_rejects_jwt_from_foreign_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token signed by a different Clerk tenant (different ``iss`` claim)
+    must be rejected with 401, even when the signature is valid and the
+    ``kid`` resolves through our JWKS — i.e. the JWK we control is also
+    served by the attacker's tenant URL.
+
+    Without ``verify_iss=True`` + ``issuer=settings.CLERK_FRONTEND_API_URL``,
+    a tenant-confusion attack would pass: the signature checks out, the
+    kid is known, and we'd silently resolve the foreign tenant's ``sub``
+    against our local user table. This test pins that the issuer claim
+    must match our configured tenant URL.
+    """
+    from app import dependencies as deps_module
+
+    monkeypatch.setattr(deps_module.settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(deps_module.settings, "CLERK_FRONTEND_API_URL", _MOCK_CLERK_URL)
+    monkeypatch.setattr(deps_module.settings, "CLERK_JWT_AUDIENCE", "")
+
+    key = _rsa_keypair()
+    jwk = _jwk_from_private(key, _MOCK_KID)
+    # Token signed with the SAME key (kid resolves) but claims a different
+    # tenant URL as issuer — this is the tenant-confusion vector.
+    token = _sign_clerk_token(
+        key,
+        sub="user_from_foreign_tenant",
+        iss="https://attacker-tenant.clerk.accounts.dev",
+    )
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock()
+
+    with patch.object(
+        deps_module, "_resolve_jwk_for_kid", AsyncMock(return_value=jwk)
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_current_user(
+                request=_request_with_bearer(token),
+                db=mock_db,
+                x_clerk_user_id=None,
+            )
+
+    assert exc_info.value.status_code == 401
+    # The foreign sub must NEVER be resolved against the local DB.
+    mock_db.execute.assert_not_awaited()
+    # Generic detail — must not leak the foreign issuer to the caller.
+    assert "attacker-tenant" not in exc_info.value.detail

--- a/backend/tests/test_clerk_url_required_in_production.py
+++ b/backend/tests/test_clerk_url_required_in_production.py
@@ -333,9 +333,7 @@ def _sign_clerk_token(
 
 
 def _request_with_bearer(token: str, *, x_header: str | None = None) -> Request:
-    headers: list[tuple[bytes, bytes]] = [
-        (b"authorization", f"Bearer {token}".encode())
-    ]
+    headers: list[tuple[bytes, bytes]] = [(b"authorization", f"Bearer {token}".encode())]
     if x_header is not None:
         headers.append((b"x-clerk-user-id", x_header.encode()))
     scope = {
@@ -438,17 +436,13 @@ async def test_production_jwt_takes_precedence_over_header(
         except Exception:
             pass
         result = MagicMock()
-        result.scalar_one_or_none.return_value = MagicMock(
-            clerk_id=jwt_sub, is_active=True
-        )
+        result.scalar_one_or_none.return_value = MagicMock(clerk_id=jwt_sub, is_active=True)
         return result
 
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(side_effect=_capture_execute)
 
-    with patch.object(
-        deps_module, "_resolve_jwk_for_kid", AsyncMock(return_value=jwk)
-    ):
+    with patch.object(deps_module, "_resolve_jwk_for_kid", AsyncMock(return_value=jwk)):
         user = await get_current_user(
             request=_request_with_bearer(token, x_header=header_sub),
             db=mock_db,
@@ -499,15 +493,15 @@ async def test_production_rejects_jwt_from_foreign_tenant(
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock()
 
-    with patch.object(
-        deps_module, "_resolve_jwk_for_kid", AsyncMock(return_value=jwk)
+    with (
+        patch.object(deps_module, "_resolve_jwk_for_kid", AsyncMock(return_value=jwk)),
+        pytest.raises(HTTPException) as exc_info,
     ):
-        with pytest.raises(HTTPException) as exc_info:
-            await get_current_user(
-                request=_request_with_bearer(token),
-                db=mock_db,
-                x_clerk_user_id=None,
-            )
+        await get_current_user(
+            request=_request_with_bearer(token),
+            db=mock_db,
+            x_clerk_user_id=None,
+        )
 
     assert exc_info.value.status_code == 401
     # The foreign sub must NEVER be resolved against the local DB.

--- a/backend/tests/test_clerk_url_required_in_production.py
+++ b/backend/tests/test_clerk_url_required_in_production.py
@@ -1,0 +1,275 @@
+"""
+Tests for Issue #90 — CLERK_FRONTEND_API_URL must be required in production.
+
+Covers three acceptance paths:
+1. Backend refuses to construct ``Settings`` in production without the URL
+   (fail-startup).
+2. Dev / staging without the URL logs a warning but does NOT crash the
+   process (preserves local-only bypass).
+3. ``get_current_user`` raises 401 on every request in production when the
+   URL is somehow missing (defense-in-depth against monkey-patched settings)
+   AND refuses to honour ``X-Clerk-User-Id`` in production even when the
+   URL is set (the actual auth-bypass vector — the header is a trusted
+   claim with no cryptographic binding).
+
+These tests exercise the security boundary directly, without spinning up the
+full ASGI app, so they remain fast and focused.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, Request
+from pydantic import ValidationError
+
+from app.config import Settings
+from app.dependencies import get_current_user
+
+# ---------------------------------------------------------------------------
+# 1. Config-level fail-startup (production refuses to boot without the URL)
+# ---------------------------------------------------------------------------
+
+
+def _make_settings(**overrides: Any) -> Settings:
+    """Build a Settings instance with .env loading disabled so tests do not
+    accidentally pick up the developer's local ``CLERK_FRONTEND_API_URL``."""
+    kwargs: dict[str, Any] = {"_env_file": None, **overrides}
+    return Settings(**kwargs)
+
+
+def test_production_without_clerk_url_fails_validation() -> None:
+    """ENVIRONMENT=production with empty CLERK_FRONTEND_API_URL must raise
+    ValidationError so the process refuses to start (Issue #90)."""
+    with pytest.raises(ValidationError) as exc_info:
+        _make_settings(
+            ENVIRONMENT="production",
+            CLERK_FRONTEND_API_URL="",
+            EXTENSION_ID="cccccccccccccccccccccccccccccccc",
+        )
+
+    err_text = str(exc_info.value)
+    assert "CLERK_FRONTEND_API_URL" in err_text
+    # Surface the bypass risk in the error so operators see it in the
+    # boot crash log.
+    assert "bypass" in err_text.lower()
+
+
+def test_production_with_clerk_url_validates_cleanly() -> None:
+    """ENVIRONMENT=production with a configured URL must validate cleanly."""
+    s = _make_settings(
+        ENVIRONMENT="production",
+        CLERK_FRONTEND_API_URL="https://clerk.example.com",
+        EXTENSION_ID="cccccccccccccccccccccccccccccccc",
+    )
+    assert s.is_production is True
+    assert s.CLERK_FRONTEND_API_URL == "https://clerk.example.com"
+    assert s.clerk_jwt_enforced is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Dev / staging warn-but-allow (preserves local-only bypass)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("env", ["development", "staging", "test"])
+def test_non_production_without_clerk_url_validates_cleanly(env: str) -> None:
+    """Dev / staging / test environments without CLERK_FRONTEND_API_URL must
+    NOT fail validation — they keep the documented header bypass for local
+    workflows. The auth dependency emits an import-time warning instead."""
+    s = _make_settings(ENVIRONMENT=env, CLERK_FRONTEND_API_URL="")
+    assert s.CLERK_FRONTEND_API_URL == ""
+    assert s.is_production is False
+    assert s.clerk_jwt_enforced is False
+
+
+@pytest.mark.parametrize("env", ["development", "staging", "test"])
+def test_warn_if_clerk_url_missing_emits_in_non_production(
+    monkeypatch: pytest.MonkeyPatch, env: str
+) -> None:
+    """``_warn_if_clerk_url_missing`` returns ``True`` and calls
+    ``logger.warning`` with an actionable message when the URL is unset
+    in any non-production environment.
+
+    Asserting on the helper's return value (instead of trying to capture
+    loguru output through caplog) keeps the test robust against other
+    test modules that replace ``loguru.logger`` with a ``SimpleNamespace``.
+    """
+    from app import dependencies as deps_module
+
+    monkeypatch.setattr(deps_module.settings, "ENVIRONMENT", env)
+    monkeypatch.setattr(deps_module.settings, "CLERK_FRONTEND_API_URL", "")
+
+    warning_calls: list[tuple[Any, ...]] = []
+
+    class _CaptureLogger:
+        def warning(self, *args: Any, **kwargs: Any) -> None:
+            warning_calls.append(args)
+
+    monkeypatch.setattr(deps_module, "logger", _CaptureLogger())
+
+    emitted = deps_module._warn_if_clerk_url_missing()
+
+    assert emitted is True
+    assert len(warning_calls) == 1
+    message = warning_calls[0][0]
+    assert "CLERK_FRONTEND_API_URL is unset" in message
+    assert "X-Clerk-User-Id" in message
+    assert "JWT verification is" in message
+
+
+def test_warn_if_clerk_url_missing_is_silent_when_url_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the URL is configured (any env), the helper must NOT warn —
+    we don't want noise on every dev request once Clerk is wired up."""
+    from app import dependencies as deps_module
+
+    monkeypatch.setattr(deps_module.settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(deps_module.settings, "CLERK_FRONTEND_API_URL", "https://clerk.example.com")
+
+    warning_calls: list[tuple[Any, ...]] = []
+
+    class _CaptureLogger:
+        def warning(self, *args: Any, **kwargs: Any) -> None:
+            warning_calls.append(args)
+
+    monkeypatch.setattr(deps_module, "logger", _CaptureLogger())
+
+    emitted = deps_module._warn_if_clerk_url_missing()
+
+    assert emitted is False
+    assert warning_calls == []
+
+
+def test_warn_if_clerk_url_missing_is_silent_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Production without the URL is handled by the config validator
+    (fail-startup), not by the import-time warning. The helper must stay
+    silent so the only signal in prod is the validator error."""
+    from app import dependencies as deps_module
+
+    monkeypatch.setattr(deps_module.settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(deps_module.settings, "CLERK_FRONTEND_API_URL", "")
+
+    warning_calls: list[tuple[Any, ...]] = []
+
+    class _CaptureLogger:
+        def warning(self, *args: Any, **kwargs: Any) -> None:
+            warning_calls.append(args)
+
+    monkeypatch.setattr(deps_module, "logger", _CaptureLogger())
+
+    emitted = deps_module._warn_if_clerk_url_missing()
+
+    assert emitted is False
+    assert warning_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Runtime 401 in production (defense in depth)
+# ---------------------------------------------------------------------------
+
+
+def _request_without_auth() -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/protected",
+        "headers": [],
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+@pytest.mark.asyncio
+async def test_production_without_clerk_url_request_returns_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defense-in-depth: even if a runtime monkey-patch leaves the URL
+    empty while ENVIRONMENT=production (the config validator would normally
+    block this at startup), get_current_user must refuse the request with
+    401 — never trust the X-Clerk-User-Id header in production."""
+    from app.dependencies import settings
+
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(
+            request=_request_without_auth(),
+            db=mock_db,
+            x_clerk_user_id="user_attacker_supplied",
+        )
+
+    assert exc_info.value.status_code == 401
+    # No DB lookup should have run — we want to fail before any user resolution.
+    mock_db.execute.assert_not_awaited()
+    # The error must NOT leak the impersonated id back to the caller.
+    assert "user_attacker_supplied" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_production_ignores_x_clerk_user_id_header_when_url_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even with CLERK_FRONTEND_API_URL configured and no Bearer token, the
+    X-Clerk-User-Id header must NEVER produce an authenticated user in
+    production. This is the actual auth-bypass vector flagged by #90: the
+    header is a trusted claim with no cryptographic binding.
+
+    Expected behaviour: 401 (Authentication required), no DB lookup."""
+    from app.dependencies import settings
+
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "https://clerk.example.com")
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(
+            request=_request_without_auth(),
+            db=mock_db,
+            x_clerk_user_id="user_attacker_supplied",
+        )
+
+    assert exc_info.value.status_code == 401
+    # Critical: header value must NOT have caused a user lookup.
+    mock_db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_development_still_honours_x_clerk_user_id_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard: tightening prod must not break the dev workflow.
+    In development with no URL, X-Clerk-User-Id is still trusted (the
+    documented bypass for local development)."""
+    from app.dependencies import settings
+
+    monkeypatch.setattr(settings, "ENVIRONMENT", "development")
+    monkeypatch.setattr(settings, "CLERK_FRONTEND_API_URL", "")
+    monkeypatch.setattr(settings, "DEV_TEST_USER_ID", "")
+
+    expected_user = MagicMock(clerk_id="user_dev_header", is_active=True)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = expected_user
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    user = await get_current_user(
+        request=_request_without_auth(),
+        db=mock_db,
+        x_clerk_user_id="user_dev_header",
+    )
+
+    assert user is expected_user
+    mock_db.execute.assert_awaited_once()

--- a/backend/tests/test_clerk_url_required_in_production.py
+++ b/backend/tests/test_clerk_url_required_in_production.py
@@ -18,11 +18,15 @@ full ASGI app, so they remain fast and focused.
 
 from __future__ import annotations
 
+import time
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import HTTPException, Request
+from jose import jwt
+from jose.utils import long_to_base64
 from pydantic import ValidationError
 
 from app.config import Settings
@@ -192,7 +196,15 @@ async def test_production_without_clerk_url_request_returns_401(
     """Defense-in-depth: even if a runtime monkey-patch leaves the URL
     empty while ENVIRONMENT=production (the config validator would normally
     block this at startup), get_current_user must refuse the request with
-    401 — never trust the X-Clerk-User-Id header in production."""
+    401 — never trust the X-Clerk-User-Id header in production.
+
+    Asserting the **exact detail string** (not just the 401 status) pins
+    the early-guard path independently from the later
+    ``not settings.clerk_jwt_enforced`` check at the header-trust step. If
+    the early guard is ever removed, the request would still 401 — but
+    with a different detail ("Authentication required.") — and this test
+    would fail loudly, surfacing the regression. See Critic 3's mutation
+    finding on round 1."""
     from app.dependencies import settings
 
     monkeypatch.setattr(settings, "ENVIRONMENT", "production")
@@ -209,6 +221,9 @@ async def test_production_without_clerk_url_request_returns_401(
         )
 
     assert exc_info.value.status_code == 401
+    # Pin the early-guard detail so deleting the guard breaks this test
+    # even though the later check would still produce a 401.
+    assert exc_info.value.detail == "Authentication unavailable: server misconfigured."
     # No DB lookup should have run — we want to fail before any user resolution.
     mock_db.execute.assert_not_awaited()
     # The error must NOT leak the impersonated id back to the caller.

--- a/backend/tests/test_clerk_url_required_in_production.py
+++ b/backend/tests/test_clerk_url_required_in_production.py
@@ -288,3 +288,178 @@ async def test_development_still_honours_x_clerk_user_id_header(
 
     assert user is expected_user
     mock_db.execute.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# 4. Production JWT happy-path + header-ignored-when-JWT-present
+# ---------------------------------------------------------------------------
+
+_MOCK_CLERK_URL = "https://test-tenant.clerk.accounts.dev"
+_MOCK_KID = "kid-test"
+
+
+def _rsa_keypair() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _jwk_from_private(key: rsa.RSAPrivateKey, kid: str) -> dict[str, str]:
+    nums = key.public_key().public_numbers()
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "use": "sig",
+        "alg": "RS256",
+        "n": long_to_base64(nums.n).decode("ascii"),
+        "e": long_to_base64(nums.e).decode("ascii"),
+    }
+
+
+def _sign_clerk_token(
+    key: rsa.RSAPrivateKey,
+    *,
+    sub: str,
+    iss: str = _MOCK_CLERK_URL,
+    kid: str = _MOCK_KID,
+) -> str:
+    """Forge a Clerk-shaped RS256 token. ``iss`` defaults to the mock tenant
+    URL so the issuer check in ``jwt.decode`` accepts the token."""
+    payload = {
+        "sub": sub,
+        "iss": iss,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 300,
+    }
+    return jwt.encode(payload, key, algorithm="RS256", headers={"kid": kid})
+
+
+def _request_with_bearer(token: str, *, x_header: str | None = None) -> Request:
+    headers: list[tuple[bytes, bytes]] = [
+        (b"authorization", f"Bearer {token}".encode())
+    ]
+    if x_header is not None:
+        headers.append((b"x-clerk-user-id", x_header.encode()))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/protected",
+        "headers": headers,
+        "query_string": b"",
+    }
+    return Request(scope)
+
+
+@pytest.mark.asyncio
+async def test_production_accepts_valid_bearer_jwt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end happy path on the JWT verification branch in production.
+
+    Round 1 had no test that actually exercised this path — the existing
+    suite only verified rejection cases. Without a positive assertion, a
+    refactor that broke ``jwt.decode``'s integration (e.g. wrong kwargs,
+    wrong algorithm allowlist) could ship green.
+
+    The test:
+      - sets ``CLERK_FRONTEND_API_URL`` to a mock tenant URL,
+      - patches ``_resolve_jwk_for_kid`` to return a valid JWK,
+      - signs a token whose ``sub`` matches the DB user's ``clerk_id``,
+      - sends it as ``Authorization: Bearer ...``,
+      - asserts the dependency returns that user (no HTTPException).
+    """
+    from app import dependencies as deps_module
+
+    monkeypatch.setattr(deps_module.settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(deps_module.settings, "CLERK_FRONTEND_API_URL", _MOCK_CLERK_URL)
+    monkeypatch.setattr(deps_module.settings, "CLERK_JWT_AUDIENCE", "")
+
+    key = _rsa_keypair()
+    jwk = _jwk_from_private(key, _MOCK_KID)
+    token = _sign_clerk_token(key, sub="test_clerk_id")
+
+    expected_user = MagicMock(clerk_id="test_clerk_id", is_active=True)
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = expected_user
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    with patch.object(
+        deps_module, "_resolve_jwk_for_kid", AsyncMock(return_value=jwk)
+    ) as resolve_mock:
+        user = await get_current_user(
+            request=_request_with_bearer(token),
+            db=mock_db,
+            x_clerk_user_id=None,
+        )
+
+    assert user is expected_user
+    resolve_mock.assert_awaited_once_with(_MOCK_KID)
+    mock_db.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_production_jwt_takes_precedence_over_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both ``Authorization: Bearer <jwt>`` and ``X-Clerk-User-Id``
+    are present in production, the resolved clerk_id MUST come from the
+    JWT's ``sub`` claim — the header is silently ignored.
+
+    A bug where the code preferred the header (or fell back to it on a
+    mismatch) would let an attacker who steals a valid JWT for "victim"
+    swap it out for their own ``X-Clerk-User-Id`` and impersonate an
+    arbitrary user. This test pins that the JWT subject wins.
+
+    Tracks Critic 5's request for "both Bearer JWT and X-Clerk-User-Id
+    present in prod — only the JWT's sub is used".
+    """
+    from app import dependencies as deps_module
+
+    monkeypatch.setattr(deps_module.settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(deps_module.settings, "CLERK_FRONTEND_API_URL", _MOCK_CLERK_URL)
+    monkeypatch.setattr(deps_module.settings, "CLERK_JWT_AUDIENCE", "")
+
+    key = _rsa_keypair()
+    jwk = _jwk_from_private(key, _MOCK_KID)
+    jwt_sub = "user_from_jwt"
+    header_sub = "user_attacker_supplied"
+    token = _sign_clerk_token(key, sub=jwt_sub)
+
+    captured_clerk_ids: list[str] = []
+
+    def _capture_execute(stmt: Any) -> Any:
+        # Pull the clerk_id literal out of the where clause so the test
+        # can assert against the *resolved* identity, not just the user
+        # object the mock returns.
+        try:
+            for clause in stmt.whereclause.clauses:
+                if "clerk_id" in str(clause):
+                    captured_clerk_ids.append(clause.right.value)
+        except Exception:
+            pass
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = MagicMock(
+            clerk_id=jwt_sub, is_active=True
+        )
+        return result
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=_capture_execute)
+
+    with patch.object(
+        deps_module, "_resolve_jwk_for_kid", AsyncMock(return_value=jwk)
+    ):
+        user = await get_current_user(
+            request=_request_with_bearer(token, x_header=header_sub),
+            db=mock_db,
+            x_clerk_user_id=header_sub,
+        )
+
+    # The DB lookup must use the JWT's subject, never the header.
+    assert captured_clerk_ids == [jwt_sub], (
+        f"Expected DB lookup to use JWT sub {jwt_sub!r}; "
+        f"actual lookups: {captured_clerk_ids!r}. If header_sub appears, "
+        f"the header bypass is live in production — Issue #90 regression."
+    )
+    assert header_sub not in captured_clerk_ids
+    assert user.clerk_id == jwt_sub

--- a/backend/tests/test_github_config.py
+++ b/backend/tests/test_github_config.py
@@ -69,8 +69,16 @@ def test_no_vault_warning_in_any_environment(monkeypatch: pytest.MonkeyPatch) ->
     never emit a 'GitHub vault not fully configured' warning, regardless
     of environment or which fields are set.
     """
+    # Issue #90 added a production guard requiring CLERK_FRONTEND_API_URL.
+    # Supply a dummy value when env=production so this test isolates the
+    # vault-warning code path under test.
     for env in ("development", "staging", "production", "test"):
         monkeypatch.setenv("ENVIRONMENT", env)
+        if env == "production":
+            monkeypatch.setenv("CLERK_FRONTEND_API_URL", "https://clerk.example.com")
+            monkeypatch.setenv("EXTENSION_ID", "cccccccccccccccccccccccccccccccc")
+        else:
+            monkeypatch.delenv("CLERK_FRONTEND_API_URL", raising=False)
         for key in ("GITHUB_TOKEN", "GITHUB_VAULT_OWNER", "GITHUB_VAULT_REPO"):
             monkeypatch.delenv(key, raising=False)
         with warnings.catch_warnings(record=True) as caught:

--- a/backend/tests/unit/test_cors_config.py
+++ b/backend/tests/unit/test_cors_config.py
@@ -9,6 +9,10 @@ def _settings(**overrides: str) -> Settings:
     base: dict[str, str] = {
         "ENVIRONMENT": "production",
         "EXTENSION_ID": "",
+        # Issue #90 added a model validator requiring CLERK_FRONTEND_API_URL
+        # in production. These CORS tests are not about that field, so we
+        # set a dummy URL by default and let individual tests override.
+        "CLERK_FRONTEND_API_URL": "https://clerk.example.com",
     }
     base.update(overrides)
     return Settings(_env_file=None, **base)  # type: ignore[call-arg,arg-type]
@@ -52,6 +56,9 @@ def test_create_app_raises_at_boot_when_production_missing_extension_id(
     config_module.get_settings.cache_clear()
     monkeypatch.setenv("ENVIRONMENT", "production")
     monkeypatch.setenv("EXTENSION_ID", "")
+    # CLERK_FRONTEND_API_URL is required in production (Issue #90); set a
+    # dummy value so this test isolates the EXTENSION_ID failure path.
+    monkeypatch.setenv("CLERK_FRONTEND_API_URL", "https://clerk.example.com")
     monkeypatch.setattr(main_module, "settings", Settings(_env_file=None))  # type: ignore[call-arg,arg-type]
 
     with pytest.raises(RuntimeError, match="EXTENSION_ID must be set"):

--- a/extension/src/options/options.ts
+++ b/extension/src/options/options.ts
@@ -191,10 +191,19 @@ async function saveAuth() {
       const email = profile.email || `${userId}@autoapply.local`;
       // Simple deterministic hash for email_hash (not sensitive — just a DB key)
       const emailHash = btoa(email).replace(/[^a-zA-Z0-9]/g, "").slice(0, 32);
+      const githubUsername = (profile.githubUsername || "").trim();
 
+      // SECURITY (#89): clerk_id is sourced server-side from authHdrs
+      // (Bearer JWT or X-Clerk-User-Id). The body intentionally omits clerk_id.
+      const registerBody: Record<string, string> = { email_hash: emailHash };
+      if (githubUsername) registerBody.github_username = githubUsername;
       const registerResp = await fetch(
-        `${apiBase}/auth/register?clerk_id=${encodeURIComponent(userId)}&email_hash=${encodeURIComponent(emailHash)}`,
-        { method: "POST" }
+        `${apiBase}/auth/register`,
+        {
+          method: "POST",
+          headers: { ...authHdrs, "Content-Type": "application/json" },
+          body: JSON.stringify(registerBody),
+        }
       );
 
       if (registerResp.ok) {

--- a/extension/src/shared/clerkConfig.ts
+++ b/extension/src/shared/clerkConfig.ts
@@ -2,10 +2,25 @@
 export const CLERK_PUBLISHABLE_KEY =
   "pk_test_ZmVhc2libGUtbGlnZXItMzUuY2xlcmsuYWNjb3VudHMuZGV2JA==";
 
-/** Read whether Clerk JWT auth is enabled from storage (default: false). */
+/**
+ * Read whether Clerk JWT auth is enabled from storage.
+ *
+ * Default: **true** (issue #90). Production backend deployments ignore the
+ * legacy ``X-Clerk-User-Id`` header outright — they require a verified RS256
+ * JWT. If this returned ``false`` by default, every existing installed
+ * extension would start getting 401s the moment that backend ships, because
+ * ``initClerk()`` would no-op and ``_clerkToken`` would never populate (the
+ * ``api.ts`` request helper falls back to the header path only when no JWT
+ * is stored).
+ *
+ * Users / operators who explicitly opt out (e.g. because the dev backend
+ * has no Clerk tenant configured) can set ``enableClerkJWT=false`` from
+ * the options page; only the explicit ``false`` value disables JWT.
+ */
 export async function getEnableClerkJWT(): Promise<boolean> {
   const data = await chrome.storage.local.get("enableClerkJWT");
-  return Boolean(data.enableClerkJWT);
+  // Treat "key not present" as enabled. Only an explicit `false` disables.
+  return data.enableClerkJWT !== false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Combined PR addressing **two P0 auth-bypass issues** that share the same code path:
- **#89**: `POST /auth/register` accepted any `clerk_id` from request body → account takeover
- **#90**: JWT validation skipped when `CLERK_FRONTEND_API_URL` unset → backend trusts `X-Clerk-User-Id` from anyone

These were originally split across `claude/fix-p0-90-b` and `claude/fix-p0-89-b`, but critic review surfaced that both PRs edit `_extract_clerk_id_from_credentials` in `dependencies.py` in overlapping ranges and the two fixes must compose correctly. This branch contains both fixes rebased into a coherent unit (8 #90 commits + 7 #89 commits + 1 R3 hardening + 1 lint).

## What changes

### #90 — JWT enforcement (8 commits)
- Pydantic validator refuses to start in production without `CLERK_FRONTEND_API_URL`
- Production header-trust path disabled — `X-Clerk-User-Id` header is never consulted when `clerk_jwt_enforced=True`
- JWT issuer pinned (`verify_iss=True, issuer=CLERK_FRONTEND_API_URL`) — blocks tenant confusion
- Extension `enableClerkJWT` defaults to `true` so installed extensions automatically send Bearer tokens
- Defense-in-depth guard at `dependencies.py:286` raises 401 with a specific detail string
- `clerk_jwt_enforced` property centralizes the policy

### #89 — `/auth/register` requires auth (7 commits)
- `clerk_id` derived from validated header/JWT, never from request body
- `RegisterRequest` schema has `extra="forbid"` — body with `clerk_id` returns 422
- New `get_authenticated_clerk_id` dependency (no DB lookup, used pre-user-row)
- `email_hash` pinned to `^[0-9a-fA-F]{64}$` (matches DB `String(64)`)
- IntegrityError race handling — only PostgreSQL `unique_violation` (pgcode 23505) routes to idempotent re-SELECT; other constraint violations log + 500
- Whitespace-only `X-Clerk-User-Id` stripped and rejected as no creds
- Extension `options.ts` sends auth headers + JSON body (no more query-string clerk_id)

### R3 hardening (1 commit, `5ed9349`)
- The `_extract_clerk_id_from_credentials` helper now skips the header path entirely when `clerk_jwt_enforced=True`, closing a P0 surfaced in R2 review where header-only requests were still trusted in production
- IntegrityError narrowed to pgcode 23505 — non-unique violations now log + 500 instead of silently routing through race recovery
- New regression test `test_register_rejects_header_only_auth_in_production`

## Test plan

- [x] All 23 original Phase 1 tests still pass
- [x] 18 new tests across `test_auth_register.py` + `test_clerk_url_required_in_production.py`
- [x] Mutation testing: removing `not clerk_jwt_enforced` gate → 2 tests fail; changing pgcode `23505→23506` → 1 test fails
- [x] Cross-tenant JWT rejection test (forged token from different `iss`) passes
- [x] Production happy-path test (real RS256 signature, mocked JWKS) passes
- [x] ruff + black clean on all touched files

Pre-existing fixture-scope errors in CI (`ScopeMismatch` on `test_engine`) affect 4 HTTP-level tests — tracked separately in #221, not caused by this PR.

## Verification process

This PR is the output of:
1. **2 parallel implementation agents** per issue (impl A + impl B), picked B for stricter defense in each case
2. **Round 1: 5 critics per issue** — surfaced 4 P0s + 7 P1/P2 findings
3. **Round 2: fix-up agents** addressed all P0s; **5 critics each** verified — #89 still had cross-PR conflict with #90
4. **Round 3: rebase + harden + 5 critics** — all 5 ACCEPT, no P0/P1 remaining

15 follow-up issues filed: #219–#233 covering observability, rate-limiting, JWT audience validation, security headers, runbooks, queue size caps, IPv6 loopback bug, auth-header consolidation, and pytest-asyncio fixture fixes.

## Risks

1. **Extension must auto-update to pick up the new `enableClerkJWT=true` default**. During the Chrome Web Store propagation window (~24-48h), installed extensions running the old bundle still send only `X-Clerk-User-Id` and will receive 401 in production. Either coordinate Web Store release before merge, OR accept temporary 401 spike for ~24h.
2. **`CLERK_FRONTEND_API_URL` and `EXTENSION_ID` must be set on Fly secrets BEFORE merge** — backend refuses to start otherwise (intentional fail-fast).
3. **`#90` standalone branch is superseded** by this PR. Close it without merging.

## Closes

- Closes #89
- Closes #90

https://claude.ai/code/session_01K7CXtKWcq3aiYmUEPMTJcu

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7CXtKWcq3aiYmUEPMTJcu)_