### PR TITLE
fix(P0): #197 — server-side LLM key resolution (no key on wire) + legacy compat + log hardening

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -128,13 +128,25 @@ class Settings(BaseSettings):
     #
     # During the Chrome Web Store rollout window, older installs still
     # POST the legacy ``providers_json`` field (which carried the keys).
-    # Setting this flag to ``True`` softens the rejection: the field is
-    # parsed for ``{name, model}`` only, the embedded ``api_key`` is
-    # stripped (the server resolves it anyway), and a WARN log records
-    # the offending user-agent so operators can track rollout progress.
-    # Default is ``False`` — once the new extension has propagated, set
-    # to ``False`` (or leave it) to enforce 422 again.
-    ACCEPT_LEGACY_PROVIDERS_JSON: bool = False
+    # When this flag is ``True`` (the default — soft-reject mode), the
+    # field is parsed for ``{name, model}`` only, the embedded
+    # ``api_key`` is stripped (the server resolves it anyway), and a
+    # WARN log records the offending user-agent so operators can track
+    # rollout progress.
+    #
+    # Default is ``True`` so a naive deploy of #197 is safe — older
+    # installs keep working until they auto-update from the Chrome Web
+    # Store. The intended rollout is:
+    #
+    #   1. Ship the backend with ``ACCEPT_LEGACY_PROVIDERS_JSON=True``
+    #      (the default). Legacy clients keep working; their UAs show up
+    #      in WARN logs.
+    #   2. Watch the Chrome Web Store rollout until the legacy-UA log
+    #      volume drops to <5% of generation traffic (>95% adoption).
+    #   3. The operator flips the flag to ``False`` via env var
+    #      (``ACCEPT_LEGACY_PROVIDERS_JSON=false``). The remaining
+    #      legacy installs now get HTTP 422 with a clear error.
+    ACCEPT_LEGACY_PROVIDERS_JSON: bool = True
 
     # ── CORS ──────────────────────────────────────────────
     # In production set EXTENSION_ID to your published Chrome extension ID

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -121,6 +121,21 @@ class Settings(BaseSettings):
     # ── Ollama ────────────────────────────────────────────
     OLLAMA_BASE_URL: str = "http://localhost:11434"
 
+    # ── Issue #197 transition ────────────────────────────
+    # Issue #197 removed the contract where the extension transmitted
+    # decrypted provider API keys on every generation request. The
+    # backend now resolves keys from ``user_provider_configs``.
+    #
+    # During the Chrome Web Store rollout window, older installs still
+    # POST the legacy ``providers_json`` field (which carried the keys).
+    # Setting this flag to ``True`` softens the rejection: the field is
+    # parsed for ``{name, model}`` only, the embedded ``api_key`` is
+    # stripped (the server resolves it anyway), and a WARN log records
+    # the offending user-agent so operators can track rollout progress.
+    # Default is ``False`` — once the new extension has propagated, set
+    # to ``False`` (or leave it) to enforce 422 again.
+    ACCEPT_LEGACY_PROVIDERS_JSON: bool = False
+
     # ── CORS ──────────────────────────────────────────────
     # In production set EXTENSION_ID to your published Chrome extension ID
     # so only your extension can call the API.

--- a/backend/app/routers/vault/_shared.py
+++ b/backend/app/routers/vault/_shared.py
@@ -40,6 +40,23 @@ _PROVIDERS_JSON_REJECT_MSG = (
 )
 
 
+def _sanitize_log_value(v: str | None) -> str:
+    """Escape CRLF and cap length on a value before it is interpolated
+    into a log line.
+
+    Issue #197 P2 (round-3) — the ``User-Agent`` header is attacker
+    controlled. A malicious client can send
+    ``User-Agent: foo\\r\\nLevel:INFO Message:fake`` to inject a
+    second, attacker-shaped log line ("log forging"). We escape
+    ``\\r`` and ``\\n`` to literal two-character sequences and cap the
+    result at 200 chars so a pathological 64KB header cannot blow up
+    the log pipeline either.
+    """
+    if not v:
+        return ""
+    return v.replace("\r", "\\r").replace("\n", "\\n")[:200]
+
+
 def _reject_providers_json(
     value: str,
     *,
@@ -71,7 +88,8 @@ def _reject_providers_json(
     if not value or not value.strip():
         return
 
-    ua = request.headers.get("user-agent", "<unknown>") if request is not None else "<unknown>"
+    raw_ua = request.headers.get("user-agent", "<unknown>") if request is not None else "<unknown>"
+    ua = _sanitize_log_value(raw_ua)
     if settings.ACCEPT_LEGACY_PROVIDERS_JSON:
         # Transition window — log and let the caller strip api_key.
         logger.warning(

--- a/backend/app/routers/vault/_shared.py
+++ b/backend/app/routers/vault/_shared.py
@@ -4,14 +4,18 @@ Shared helpers and singletons used across vault sub-modules.
 
 import json as _json
 
+from fastapi import HTTPException, status
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.user import User
+from app.models.user_provider_config import UserProviderConfig
 from app.services.ats_service import ATSResult
 from app.services.github_service import GitHubService
 from app.services.resume_parser import ResumeParser
 from app.services.retrieval_agent import ResumeWithScore, RetrievalAgent
+from app.services.user_provider_configs import resolve_decrypted_key, resolve_user_providers
 
 # ── Singletons ─────────────────────────────────────────────────────────────
 
@@ -20,36 +24,108 @@ _resume_parser = ResumeParser()
 _github_service = GitHubService()
 
 
-# ── Provider resolution ────────────────────────────────────────────────────
+# ── Provider resolution (Issue #197 — server-side keys only) ───────────────
+
+
+_PROVIDERS_JSON_REJECT_MSG = (
+    "providers_json is no longer accepted. The client must send "
+    "`providers` as a JSON list of {name, model} objects; API keys are "
+    "resolved server-side from the user's provider configs (Issue #197)."
+)
+
+
+def _reject_providers_json(value: str, *, field_name: str = "providers_json") -> None:
+    """Raise 422 if the deprecated ``providers_json`` field is present.
+
+    Issue #197 removed the contract where the client transmits decrypted
+    API keys on every request. We refuse the old field outright (no
+    silent fallback) so misconfigured clients fail loudly instead of
+    silently leaking keys over the wire.
+    """
+    if value and value.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={"error": "providers_json_removed", "message": _PROVIDERS_JSON_REJECT_MSG},
+        )
+
+
+def _parse_providers(providers: str) -> list[dict]:
+    """Parse the new ``providers`` form field — JSON list of ``{name, model}``.
+
+    Returns ``[]`` for empty / whitespace-only input. Raises 422 on
+    malformed JSON or a non-list payload so the client gets a clear
+    error.
+    """
+    if not providers or not providers.strip():
+        return []
+    try:
+        parsed = _json.loads(providers)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "invalid_providers",
+                "message": f"providers field must be JSON: {exc}",
+            },
+        ) from exc
+    if not isinstance(parsed, list):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "error": "invalid_providers",
+                "message": "providers must be a JSON list of {name, model} objects",
+            },
+        )
+    # Strip out any stray api_key keys the client might still send — they
+    # are explicitly ignored now.
+    return [
+        {"name": str(e.get("name", "")), "model": str(e.get("model", ""))}
+        for e in parsed
+        if isinstance(e, dict)
+    ]
 
 
 async def _resolve_providers(
-    providers_json: str,
+    providers: str,
     db: "AsyncSession",
     user: "User",
+    *,
+    providers_json: str | None = None,
 ) -> list[dict]:
+    """Resolve the provider list for a generation endpoint.
+
+    Issue #197 — the request body now carries only ``providers`` as a
+    JSON list of ``{name, model}``. API keys live in the
+    ``user_provider_configs`` table and are decrypted in-memory via
+    :func:`resolve_decrypted_key`.
+
+    The legacy ``providers_json`` parameter (which used to carry decrypted
+    API keys from the client) is rejected with 422 — no backward-compat
+    window. Callers must pass it to this helper so we get a single,
+    consistent rejection path.
+
+    Returned entries::
+
+        [{"name": "anthropic", "model": "...", "api_key": DecryptedKey}, ...]
+
+    ``api_key`` is a :class:`DecryptedKey` instance — call ``.expose()``
+    only at the boundary that hands it to the LLM provider.
+
+    When ``providers`` is empty, fall back to *every* server-side config
+    the user has stored (legacy behaviour for clients that just send
+    ``providers=""``). Each row goes through ``resolve_decrypted_key`` so
+    a corrupt row is skipped rather than crashing the request.
     """
-    Resolve the provider list for a generation endpoint.
+    if providers_json is not None:
+        _reject_providers_json(providers_json)
 
-    Priority:
-    1. providers_json from request body (client-configured, backward-compat)
-    2. Server-side UserProviderConfig rows (if providers_json is empty)
-    3. Empty list → keyword fallback handled downstream
+    requested = _parse_providers(providers)
+    if requested:
+        return await resolve_user_providers(user.id, requested, db)
 
-    This implements issue #25: server-side provider authority.
-    """
-    from sqlalchemy import select
-
-    from app.models.user_provider_config import UserProviderConfig
-    from app.utils.encryption import decrypt_value
-
-    if providers_json.strip():
-        try:
-            return _json.loads(providers_json)  # type: ignore[return-value]
-        except Exception:
-            logger.warning("Invalid providers_json — falling back to server-side config")
-
-    # Read from server-side storage
+    # No client-supplied list — pull every configured provider from the DB
+    # so existing flows (which historically relied on the server-side
+    # fallback path) keep working.
     result = await db.execute(
         select(UserProviderConfig)
         .where(
@@ -59,17 +135,56 @@ async def _resolve_providers(
         .order_by(UserProviderConfig.provider_name)
     )
     rows = result.scalars().all()
-    providers = []
+
+    enriched: list[dict] = []
     for row in rows:
-        try:
-            api_key = decrypt_value(row.encrypted_api_key) if row.encrypted_api_key else ""
-        except Exception:
-            api_key = ""
-        if api_key:
-            providers.append(
-                {"name": row.provider_name, "api_key": api_key, "model": row.model_override or ""}
+        key = await resolve_decrypted_key(user.id, row.provider_name, db)
+        if key is None:
+            logger.debug(
+                "_resolve_providers: skipping {} (decrypt returned None)", row.provider_name
             )
-    return providers
+            continue
+        enriched.append(
+            {
+                "name": row.provider_name,
+                "model": row.model_override or "",
+                "api_key": key,
+            }
+        )
+    return enriched
+
+
+def _expose_providers_for_gateway(providers: list[dict]) -> list[dict]:
+    """Convert ``DecryptedKey``-wrapped entries to plaintext-key entries.
+
+    The downstream ``resume_generator`` helpers still expect
+    ``{"name", "api_key": str, "model"}`` because they pass ``api_key``
+    straight to ``LLMGateway.generate(api_key=...)``. We unwrap exactly
+    here so ``.expose()`` is invoked at a single, auditable boundary.
+
+    Ollama entries have ``api_key=None`` and are emitted as ``""`` for
+    the gateway call.
+    """
+    out: list[dict] = []
+    for p in providers:
+        raw = p.get("api_key")
+        if raw is None:
+            plaintext = ""
+        elif isinstance(raw, str):
+            # Defensive — shouldn't happen after resolve_user_providers,
+            # but the cascade helpers occasionally re-enter with already
+            # plain entries (tests).
+            plaintext = raw
+        else:
+            plaintext = raw.expose()
+        out.append(
+            {
+                "name": p.get("name", ""),
+                "model": p.get("model", ""),
+                "api_key": plaintext,
+            }
+        )
+    return out
 
 
 # ── Serialisation helpers ──────────────────────────────────────────────────

--- a/backend/app/routers/vault/_shared.py
+++ b/backend/app/routers/vault/_shared.py
@@ -3,8 +3,9 @@ Shared helpers and singletons used across vault sub-modules.
 """
 
 import json as _json
+import uuid as _uuid
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException, Request, status
 from loguru import logger
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,19 +39,45 @@ _PROVIDERS_JSON_REJECT_MSG = (
 )
 
 
-def _reject_providers_json(value: str, *, field_name: str = "providers_json") -> None:
-    """Raise 422 if the deprecated ``providers_json`` field is present.
+def _reject_providers_json(
+    value: str,
+    *,
+    field_name: str = "providers_json",
+    user_id: _uuid.UUID | None = None,
+    request: Request | None = None,
+) -> None:
+    """Reject the deprecated ``providers_json`` field with HTTP 422.
 
     Issue #197 removed the contract where the client transmits decrypted
-    API keys on every request. We refuse the old field outright (no
-    silent fallback) so misconfigured clients fail loudly instead of
-    silently leaking keys over the wire.
+    API keys on every request. We refuse the old field outright so
+    misconfigured clients fail loudly instead of silently leaking keys
+    over the wire.
+
+    Observability (P1-F): every rejection logs a structured WARNING with
+    the user id and ``User-Agent`` header BEFORE raising
+    ``HTTPException`` so operators can identify which extension installs
+    are still on the legacy contract during the Chrome Web Store
+    rollout. The previous round-1 implementation raised silently — once
+    the exception propagated out, the request was 422'd with no log
+    line and operators had no signal at all about which client versions
+    were still calling.
     """
-    if value and value.strip():
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={"error": "providers_json_removed", "message": _PROVIDERS_JSON_REJECT_MSG},
-        )
+    if not value or not value.strip():
+        return
+
+    ua = request.headers.get("user-agent", "<unknown>") if request is not None else "<unknown>"
+    # Log first so operators see WHICH clients are being rejected
+    # (HTTPException doesn't carry request context into the logs by
+    # default).
+    logger.warning(
+        "legacy_providers_json_rejected user={} ua={}",
+        user_id,
+        ua,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        detail={"error": "providers_json_removed", "message": _PROVIDERS_JSON_REJECT_MSG},
+    )
 
 
 def _parse_providers(providers: str) -> list[dict]:
@@ -95,6 +122,7 @@ async def _resolve_providers(
     user: "User",
     *,
     providers_json: str | None = None,
+    request: Request | None = None,
 ) -> list[dict]:
     """Resolve the provider list for a generation endpoint.
 
@@ -121,7 +149,7 @@ async def _resolve_providers(
     a corrupt row is skipped rather than crashing the request.
     """
     if providers_json is not None:
-        _reject_providers_json(providers_json)
+        _reject_providers_json(providers_json, user_id=user.id, request=request)
 
     requested = _parse_providers(providers)
     if requested:

--- a/backend/app/routers/vault/_shared.py
+++ b/backend/app/routers/vault/_shared.py
@@ -10,6 +10,7 @@ from loguru import logger
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.models.user import User
 from app.models.user_provider_config import UserProviderConfig
 from app.services.ats_service import ATSResult
@@ -46,29 +47,43 @@ def _reject_providers_json(
     user_id: _uuid.UUID | None = None,
     request: Request | None = None,
 ) -> None:
-    """Reject the deprecated ``providers_json`` field with HTTP 422.
+    """Reject or soften the deprecated ``providers_json`` field.
 
     Issue #197 removed the contract where the client transmits decrypted
-    API keys on every request. We refuse the old field outright so
-    misconfigured clients fail loudly instead of silently leaking keys
-    over the wire.
+    API keys on every request. The default behaviour is hard 422 — no
+    backward-compat window — so misconfigured clients fail loudly.
 
     Observability (P1-F): every rejection logs a structured WARNING with
-    the user id and ``User-Agent`` header BEFORE raising
-    ``HTTPException`` so operators can identify which extension installs
-    are still on the legacy contract during the Chrome Web Store
-    rollout. The previous round-1 implementation raised silently — once
-    the exception propagated out, the request was 422'd with no log
-    line and operators had no signal at all about which client versions
-    were still calling.
+    the user id and ``User-Agent`` header so operators can identify
+    which extension installs are still on the legacy contract during
+    the Chrome Web Store rollout.
+
+    Transition window (P0-G): when
+    :attr:`Settings.ACCEPT_LEGACY_PROVIDERS_JSON` is ``True``, the field
+    is NOT rejected. Instead this function returns silently after
+    logging a WARNING. The caller (``_resolve_providers``) is
+    responsible for parsing the legacy payload and stripping the
+    embedded ``api_key`` so it never reaches downstream — the server
+    resolves keys from ``user_provider_configs`` regardless. Operators
+    should flip the flag back to ``False`` once the new extension is
+    fully rolled out.
     """
     if not value or not value.strip():
         return
 
     ua = request.headers.get("user-agent", "<unknown>") if request is not None else "<unknown>"
-    # Log first so operators see WHICH clients are being rejected
-    # (HTTPException doesn't carry request context into the logs by
-    # default).
+    if settings.ACCEPT_LEGACY_PROVIDERS_JSON:
+        # Transition window — log and let the caller strip api_key.
+        logger.warning(
+            "legacy_providers_json_accepted user={} ua={} reason=ACCEPT_LEGACY_PROVIDERS_JSON",
+            user_id,
+            ua,
+        )
+        return
+
+    # Strict mode — log first so operators can see WHICH clients are
+    # being rejected (an HTTPException after this point doesn't carry
+    # request context into the logs by default).
     logger.warning(
         "legacy_providers_json_rejected user={} ua={}",
         user_id,
@@ -116,6 +131,37 @@ def _parse_providers(providers: str) -> list[dict]:
     ]
 
 
+def _parse_legacy_providers_json_stripped(value: str) -> list[dict]:
+    """Parse the legacy ``providers_json`` form field and strip ``api_key``.
+
+    Issue #197 P0-G — only invoked when
+    :attr:`Settings.ACCEPT_LEGACY_PROVIDERS_JSON` is ``True``. The
+    embedded ``api_key`` value is dropped on the floor (the server
+    resolves keys server-side regardless) so even in the transition
+    window a legacy client cannot smuggle a key past us.
+
+    Returns the same shape as ``_parse_providers``. Malformed JSON or a
+    non-list payload is treated as "no providers" so a buggy legacy
+    client falls through to the empty-list server-fallback rather than
+    failing the request — the goal of the flag is to keep old installs
+    working during rollout.
+    """
+    if not value or not value.strip():
+        return []
+    try:
+        parsed = _json.loads(value)
+    except Exception:
+        logger.warning("legacy_providers_json_unparseable — falling back to server enumeration")
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [
+        {"name": str(e.get("name", "")), "model": str(e.get("model", ""))}
+        for e in parsed
+        if isinstance(e, dict)
+    ]
+
+
 async def _resolve_providers(
     providers: str,
     db: "AsyncSession",
@@ -152,6 +198,18 @@ async def _resolve_providers(
         _reject_providers_json(providers_json, user_id=user.id, request=request)
 
     requested = _parse_providers(providers)
+    # P0-G transition window — when the flag is on and the legacy field
+    # carried provider entries, fall back to them so the request still
+    # works. The ``api_key`` inside is stripped by the parser; the
+    # server resolves keys from ``user_provider_configs`` regardless.
+    if (
+        not requested
+        and providers_json
+        and providers_json.strip()
+        and settings.ACCEPT_LEGACY_PROVIDERS_JSON
+    ):
+        requested = _parse_legacy_providers_json_stripped(providers_json)
+
     if requested:
         # Strict mode — the client explicitly named providers. If any of
         # them lacks a server-side key, surface HTTP 400 with the missing

--- a/backend/app/routers/vault/_shared.py
+++ b/backend/app/routers/vault/_shared.py
@@ -15,7 +15,11 @@ from app.services.ats_service import ATSResult
 from app.services.github_service import GitHubService
 from app.services.resume_parser import ResumeParser
 from app.services.retrieval_agent import ResumeWithScore, RetrievalAgent
-from app.services.user_provider_configs import resolve_decrypted_key, resolve_user_providers
+from app.services.user_provider_configs import (
+    ProviderNotConfiguredError,
+    resolve_decrypted_key,
+    resolve_user_providers,
+)
 
 # ── Singletons ─────────────────────────────────────────────────────────────
 
@@ -121,11 +125,29 @@ async def _resolve_providers(
 
     requested = _parse_providers(providers)
     if requested:
-        return await resolve_user_providers(user.id, requested, db)
+        # Strict mode — the client explicitly named providers. If any of
+        # them lacks a server-side key, surface HTTP 400 with the missing
+        # provider name so the extension can prompt the user to add the
+        # key in Options instead of silently falling back to keyword-only
+        # generation (which would look like a quality regression).
+        try:
+            return await resolve_user_providers(user.id, requested, db, strict=True)
+        except ProviderNotConfiguredError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "error": "provider_not_configured",
+                    "provider": exc.provider_name,
+                    "message": str(exc),
+                },
+            ) from exc
 
-    # No client-supplied list — pull every configured provider from the DB
-    # so existing flows (which historically relied on the server-side
-    # fallback path) keep working.
+    # No client-supplied list — server-side fallback: pull every
+    # configured provider from the DB. This is the documented
+    # backward-compatible path for clients that send ``providers=""`` and
+    # let the server enumerate user configs. Drops (corrupt rows, decrypt
+    # failures) are logged at INFO so operators can spot them; the empty
+    # final list flows through to the keyword fallback in the endpoint.
     result = await db.execute(
         select(UserProviderConfig)
         .where(
@@ -140,8 +162,12 @@ async def _resolve_providers(
     for row in rows:
         key = await resolve_decrypted_key(user.id, row.provider_name, db)
         if key is None:
-            logger.debug(
-                "_resolve_providers: skipping {} (decrypt returned None)", row.provider_name
+            # Promoted from DEBUG → INFO so the silent drop is visible at
+            # the default log level (Issue #197 P1-F observability gap).
+            logger.info(
+                "provider_skipped user={} provider={} reason=decrypt_failed_or_empty",
+                user.id,
+                row.provider_name,
             )
             continue
         enriched.append(

--- a/backend/app/routers/vault/_shared.py
+++ b/backend/app/routers/vault/_shared.py
@@ -22,6 +22,7 @@ from app.services.user_provider_configs import (
     resolve_decrypted_key,
     resolve_user_providers,
 )
+from app.utils.log_safety import sanitize_log_value as _sanitize_log_value
 
 # ── Singletons ─────────────────────────────────────────────────────────────
 
@@ -38,23 +39,6 @@ _PROVIDERS_JSON_REJECT_MSG = (
     "`providers` as a JSON list of {name, model} objects; API keys are "
     "resolved server-side from the user's provider configs (Issue #197)."
 )
-
-
-def _sanitize_log_value(v: str | None) -> str:
-    """Escape CRLF and cap length on a value before it is interpolated
-    into a log line.
-
-    Issue #197 P2 (round-3) — the ``User-Agent`` header is attacker
-    controlled. A malicious client can send
-    ``User-Agent: foo\\r\\nLevel:INFO Message:fake`` to inject a
-    second, attacker-shaped log line ("log forging"). We escape
-    ``\\r`` and ``\\n`` to literal two-character sequences and cap the
-    result at 200 chars so a pathological 64KB header cannot blow up
-    the log pipeline either.
-    """
-    if not v:
-        return ""
-    return v.replace("\r", "\\r").replace("\n", "\\n")[:200]
 
 
 def _reject_providers_json(
@@ -268,10 +252,12 @@ async def _resolve_providers(
         if key is None:
             # Promoted from DEBUG → INFO so the silent drop is visible at
             # the default log level (Issue #197 P1-F observability gap).
+            # ``row.provider_name`` was user-supplied at the time the row
+            # was written — sanitize defensively (CWE-117 belt-and-braces).
             logger.info(
                 "provider_skipped user={} provider={} reason=decrypt_failed_or_empty",
                 user.id,
-                row.provider_name,
+                _sanitize_log_value(row.provider_name),
             )
             continue
         enriched.append(

--- a/backend/app/routers/vault/answers.py
+++ b/backend/app/routers/vault/answers.py
@@ -230,7 +230,14 @@ TEXT TO SHORTEN:
         for p in sorted_p:
             name = p.get("name", "")
             api_key = p.get("api_key", "")
-            if not name or not api_key:
+            # Issue #197 follow-up: ollama is the only provider that needs
+            # no API key (local server). After ``_expose_providers_for_gateway``
+            # its ``api_key`` is the empty string, so a naive
+            # ``if not api_key: continue`` would skip it entirely. Allow it
+            # through explicitly here.
+            if not name:
+                continue
+            if name != "ollama" and not api_key:
                 continue
             try:
                 raw, _provider_used = await gateway.generate(

--- a/backend/app/routers/vault/answers.py
+++ b/backend/app/routers/vault/answers.py
@@ -2,9 +2,7 @@
 Vault sub-module: answer generation, saving, feedback, search, and retrieval.
 """
 
-import contextlib
 import hashlib
-import json as _json
 import sys
 import unicodedata
 import uuid
@@ -28,7 +26,7 @@ from app.services.resume_generator import (
     generate_answer_drafts_parallel,
 )
 
-from ._shared import _resolve_providers
+from ._shared import _expose_providers_for_gateway, _reject_providers_json, _resolve_providers
 
 
 def _agent():
@@ -51,9 +49,13 @@ async def generate_answers(
     jd_text: str = Form(""),
     work_history_text: str = Form(""),  # optional — auto-filled from DB if empty
     llm_provider: str = Form("anthropic"),
-    llm_api_key: str | None = Form(None),
     ollama_model: str = Form("llama3.1:8b"),
-    providers_json: str = Form(""),  # JSON: [{"name":"groq","api_key":"...","model":"..."}]
+    # Issue #197 — client now sends only ``{name, model}`` per provider.
+    # ``providers_json`` is the legacy field that used to carry decrypted
+    # API keys; we accept it as a form field only so we can reject it
+    # with a clear 422 (the legacy contract is gone).
+    providers: str = Form(""),  # JSON: [{"name": "groq", "model": "..."}]
+    providers_json: str = Form(""),  # DEPRECATED — rejected with 422
     max_length: int = Form(0),  # textarea maxlength — 0 means no limit
     category_instructions: str = Form(""),  # per-category style instructions from user settings
     db: AsyncSession = Depends(get_db),
@@ -88,8 +90,16 @@ async def generate_answers(
     past_texts = [ans.answer_text for _, ans in best_past if (ans.reward_score or 0) >= 0.6]
 
     # Cascade mode: try providers in priority order, use first that works for all 3 drafts
-    # #25: prefer server-side config when client sends empty providers_json
-    providers_list: list[dict] = await _resolve_providers(providers_json, db, user)
+    # Issue #197 — keys are resolved server-side; ``providers_json`` is
+    # rejected upfront and ``providers`` carries only ``{name, model}``.
+    providers_list_wrapped: list[dict] = await _resolve_providers(
+        providers, db, user, providers_json=providers_json
+    )
+    # Unwrap DecryptedKey for the downstream generator helpers, which
+    # pass ``api_key`` straight to ``LLMGateway.generate``. Calling
+    # ``.expose()`` here keeps the leak surface to a single, auditable
+    # boundary.
+    providers_list: list[dict] = _expose_providers_for_gateway(providers_list_wrapped)
 
     # Resolve candidate name for cover letter greeting
     candidate_name = ""
@@ -148,6 +158,11 @@ async def generate_answers(
             if provider_used and provider_used != "fallback":
                 draft_providers = [provider_used] * len(drafts)
     else:
+        # No server-side providers configured — fall through to the
+        # keyword/rule-based path inside ``generate_answer_drafts``.
+        # Issue #197: client no longer transmits llm_api_key; the per-
+        # user legacy ``encrypted_llm_api_key`` column is not in scope
+        # for this issue.
         drafts = await generate_answer_drafts(
             question_text=question_text,
             question_category=question_category,
@@ -156,7 +171,7 @@ async def generate_answers(
             jd_text=jd_text,
             work_history_text=work_history_text,
             provider=llm_provider,
-            api_key=llm_api_key or user.encrypted_llm_api_key or "",
+            api_key="",
             ollama_model=ollama_model,
             past_accepted_answers=past_texts or None,
             rag_context=answer_rag_ctx,
@@ -178,7 +193,8 @@ async def generate_answers(
 async def trim_answer(
     answer_text: str = Form(...),
     max_chars: int = Form(...),
-    providers_json: str = Form(""),
+    providers: str = Form(""),  # JSON: [{"name": "groq", "model": "..."}]
+    providers_json: str = Form(""),  # DEPRECATED — rejected with 422
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> dict:
@@ -190,10 +206,9 @@ async def trim_answer(
     if len(answer_text) <= max_chars:
         return {"trimmed": answer_text, "char_count": len(answer_text), "provider_used": "none"}
 
-    providers_list: list[dict] = []
-    if providers_json.strip():
-        with contextlib.suppress(Exception):
-            providers_list = _json.loads(providers_json)
+    _reject_providers_json(providers_json)
+    providers_list_wrapped: list[dict] = await _resolve_providers(providers, db, user)
+    providers_list: list[dict] = _expose_providers_for_gateway(providers_list_wrapped)
 
     system_prompt = "You are a precise editor. Your only task is to shorten text to fit a strict character limit while preserving meaning, tone, and all key facts. Return ONLY the shortened text — no commentary."
     target_words = max(30, (max_chars // 5) - 10)

--- a/backend/app/routers/vault/generate.py
+++ b/backend/app/routers/vault/generate.py
@@ -2,9 +2,7 @@
 Vault sub-module: resume and content generation endpoints.
 """
 
-import contextlib
 import hashlib
-import json as _json
 import sys
 import uuid
 
@@ -20,7 +18,12 @@ from app.models.work_history import WorkHistoryEntry
 from app.services.ats_service import ATSResult
 from app.services.resume_generator import PersonalProfile
 
-from ._shared import _github_service
+from ._shared import (
+    _expose_providers_for_gateway,
+    _github_service,
+    _reject_providers_json,
+    _resolve_providers,
+)
 
 
 def _score_resume():
@@ -80,10 +83,10 @@ async def generate_resume(
     portfolio_label: str = Form(""),
     work_history_text: str = Form(...),
     education_text: str = Form(""),
-    # LLM config
+    # LLM config — Issue #197: API keys live server-side only.
     llm_provider: str = Form("anthropic"),
-    llm_api_key: str | None = Form(None),
     ollama_model: str = Form("llama3.1:8b"),
+    providers_json: str = Form(""),  # DEPRECATED — rejected with 422
     # Base resume for ATS pre-scoring
     base_resume_id: str | None = Form(None),
     db: AsyncSession = Depends(get_db),
@@ -133,6 +136,19 @@ async def generate_resume(
         education_text=education_text,
     )
 
+    # Issue #197 — reject the deprecated client-side ``providers_json``
+    # field before doing any work.
+    _reject_providers_json(providers_json)
+
+    # Resolve the server-side key for ``llm_provider`` (if any). The
+    # client no longer transmits ``llm_api_key`` — it is decrypted from
+    # ``user_provider_configs`` here and exposed at the single boundary
+    # below.
+    from app.services.user_provider_configs import resolve_decrypted_key
+
+    decrypted = await resolve_decrypted_key(user.id, llm_provider, db)
+    api_key_plain = decrypted.expose() if decrypted is not None else ""
+
     generated = await _generate_full_latex_resume()(
         profile=profile,
         jd_text=jd_text,
@@ -141,7 +157,7 @@ async def generate_resume(
         job_id=job_id,
         ats_result=ats_result,
         provider=llm_provider,
-        api_key=llm_api_key or user.encrypted_llm_api_key or "",
+        api_key=api_key_plain,
         ollama_model=ollama_model,
         rag_context=rag_ctx,
     )
@@ -230,7 +246,8 @@ async def generate_tailored_resume(
     jd_text: str = Form(...),
     company_name: str = Form(...),
     role_title: str = Form(""),
-    providers_json: str = Form(""),  # JSON: [{"name":"groq","api_key":"...","model":"..."}]
+    providers: str = Form(""),  # JSON: [{"name": "groq", "model": "..."}]
+    providers_json: str = Form(""),  # DEPRECATED — rejected with 422
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
@@ -287,19 +304,20 @@ async def generate_tailored_resume(
         education_text="",
     )
 
-    # Resolve provider — use first entry in providers_json, fallback to user's stored key
-    providers_list: list[dict] = []
-    if providers_json.strip():
-        try:
-            providers_list = _json.loads(providers_json)
-        except Exception:
-            logger.warning("generate/tailored: invalid providers_json — using fallback")
+    # Issue #197 — keys come from server-side configs. Reject the
+    # deprecated ``providers_json`` field, parse ``providers``, and
+    # decrypt at a single ``.expose()`` boundary below.
+    providers_list_wrapped: list[dict] = await _resolve_providers(
+        providers, db, user, providers_json=providers_json
+    )
 
     provider = "anthropic"
-    api_key = user.encrypted_llm_api_key or ""
-    if providers_list:
-        provider = providers_list[0].get("name", "anthropic")
-        api_key = providers_list[0].get("api_key", "") or api_key
+    api_key = ""
+    if providers_list_wrapped:
+        first = providers_list_wrapped[0]
+        provider = first.get("name", "anthropic")
+        key_obj = first.get("api_key")
+        api_key = key_obj.expose() if key_obj is not None else ""
 
     generated = await _generate_full_latex_resume()(
         profile=profile,
@@ -363,7 +381,8 @@ async def generate_summary_endpoint(
     jd_text: str = Form(""),
     word_limit: int = Form(80),
     candidate_name: str = Form(""),
-    providers_json: str = Form(""),
+    providers: str = Form(""),  # JSON: [{"name": "groq", "model": "..."}]
+    providers_json: str = Form(""),  # DEPRECATED — rejected with 422
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> dict:
@@ -371,10 +390,10 @@ async def generate_summary_endpoint(
     Generate a 2-4 sentence professional summary tailored to a role.
     Returns {summary, provider_used, word_count}.
     """
-    providers_list: list[dict] = []
-    with contextlib.suppress(Exception):
-        if providers_json.strip():
-            providers_list = _json.loads(providers_json)
+    providers_list_wrapped: list[dict] = await _resolve_providers(
+        providers, db, user, providers_json=providers_json
+    )
+    providers_list: list[dict] = _expose_providers_for_gateway(providers_list_wrapped)
 
     from app.models.work_history import WorkHistoryEntry as WHModel
 
@@ -420,7 +439,8 @@ async def generate_bullets_endpoint(
     jd_text: str = Form(""),
     num_bullets: int = Form(5),
     target_company_for_context: str = Form(""),
-    providers_json: str = Form(""),
+    providers: str = Form(""),  # JSON: [{"name": "groq", "model": "..."}]
+    providers_json: str = Form(""),  # DEPRECATED — rejected with 422
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> dict:
@@ -428,10 +448,10 @@ async def generate_bullets_endpoint(
     Generate ATS-optimized bullet points for a specific role, grounded in work history.
     Returns {bullets, provider_used, count}.
     """
-    providers_list: list[dict] = []
-    with contextlib.suppress(Exception):
-        if providers_json.strip():
-            providers_list = _json.loads(providers_json)
+    providers_list_wrapped: list[dict] = await _resolve_providers(
+        providers, db, user, providers_json=providers_json
+    )
+    providers_list: list[dict] = _expose_providers_for_gateway(providers_list_wrapped)
 
     from app.models.work_history import WorkHistoryEntry as WHModel
 
@@ -478,7 +498,8 @@ async def generate_cover_letter_endpoint(
     tone: str = Form("professional"),  # professional|enthusiastic|concise|conversational
     word_limit: int = Form(400),
     candidate_name: str = Form(""),
-    providers_json: str = Form(""),
+    providers: str = Form(""),  # JSON: [{"name": "groq", "model": "..."}]
+    providers_json: str = Form(""),  # DEPRECATED — rejected with 422
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ) -> dict:
@@ -486,10 +507,10 @@ async def generate_cover_letter_endpoint(
     Generate cover letter drafts — one per enabled LLM provider, run in parallel.
     Accepts tone and word_limit controls. Returns up to N drafts (one per provider).
     """
-    providers_list: list[dict] = []
-    with contextlib.suppress(Exception):
-        if providers_json.strip():
-            providers_list = _json.loads(providers_json)
+    providers_list_wrapped: list[dict] = await _resolve_providers(
+        providers, db, user, providers_json=providers_json
+    )
+    providers_list: list[dict] = _expose_providers_for_gateway(providers_list_wrapped)
 
     # Load candidate work history
     from app.models.work_history import WorkHistoryEntry as WHModel  # local import avoids circular

--- a/backend/app/routers/vault/generate.py
+++ b/backend/app/routers/vault/generate.py
@@ -17,6 +17,7 @@ from app.models.user import User
 from app.models.work_history import WorkHistoryEntry
 from app.services.ats_service import ATSResult
 from app.services.resume_generator import PersonalProfile
+from app.services.user_provider_configs import resolve_decrypted_key
 
 from ._shared import (
     _expose_providers_for_gateway,
@@ -24,6 +25,36 @@ from ._shared import (
     _reject_providers_json,
     _resolve_providers,
 )
+
+
+def _first_provider_for_gateway(
+    wrapped: list[dict],
+    *,
+    default_provider: str = "anthropic",
+) -> tuple[str, str]:
+    """Pick the first wrapped provider entry and expose its key.
+
+    Issue #197 P1-E — both ``generate_resume`` and ``generate_tailored_resume``
+    used to open-code ``key_obj.expose() if key_obj is not None else ""``
+    at the call site. That drift duplicates the single sanctioned
+    ``.expose()`` boundary and makes the leak surface harder to audit.
+
+    Returns ``(provider_name, plaintext_api_key)``. When ``wrapped`` is
+    empty the defaults flow through (``default_provider``, ``""``).
+    Ollama entries have ``api_key=None`` and emit ``""`` for the
+    gateway call (gateway treats it as the no-auth marker).
+    """
+    if not wrapped:
+        return default_provider, ""
+    first = wrapped[0]
+    name = first.get("name") or default_provider
+    key_obj = first.get("api_key")
+    if key_obj is None:
+        return name, ""
+    if isinstance(key_obj, str):
+        # Defensive — tests sometimes build provider dicts directly.
+        return name, key_obj
+    return name, key_obj.expose()
 
 
 def _score_resume():
@@ -142,12 +173,13 @@ async def generate_resume(
 
     # Resolve the server-side key for ``llm_provider`` (if any). The
     # client no longer transmits ``llm_api_key`` — it is decrypted from
-    # ``user_provider_configs`` here and exposed at the single boundary
-    # below.
-    from app.services.user_provider_configs import resolve_decrypted_key
-
+    # ``user_provider_configs`` here and exposed via the shared helper
+    # so every ``.expose()`` site is auditable from one place.
     decrypted = await resolve_decrypted_key(user.id, llm_provider, db)
-    api_key_plain = decrypted.expose() if decrypted is not None else ""
+    _, api_key_plain = _first_provider_for_gateway(
+        [{"name": llm_provider, "model": "", "api_key": decrypted}],
+        default_provider=llm_provider,
+    )
 
     generated = await _generate_full_latex_resume()(
         profile=profile,
@@ -306,18 +338,12 @@ async def generate_tailored_resume(
 
     # Issue #197 — keys come from server-side configs. Reject the
     # deprecated ``providers_json`` field, parse ``providers``, and
-    # decrypt at a single ``.expose()`` boundary below.
+    # decrypt at the single shared ``.expose()`` boundary
+    # (``_first_provider_for_gateway``).
     providers_list_wrapped: list[dict] = await _resolve_providers(
         providers, db, user, providers_json=providers_json
     )
-
-    provider = "anthropic"
-    api_key = ""
-    if providers_list_wrapped:
-        first = providers_list_wrapped[0]
-        provider = first.get("name", "anthropic")
-        key_obj = first.get("api_key")
-        api_key = key_obj.expose() if key_obj is not None else ""
+    provider, api_key = _first_provider_for_gateway(providers_list_wrapped)
 
     generated = await _generate_full_latex_resume()(
         profile=profile,

--- a/backend/app/routers/vault/interview.py
+++ b/backend/app/routers/vault/interview.py
@@ -14,6 +14,8 @@ from app.models.user import User
 from app.models.work_history import WorkHistoryEntry
 from app.services.llm_gateway import LLMGateway
 
+from ._shared import _expose_providers_for_gateway, _resolve_providers
+
 router = APIRouter()
 
 
@@ -48,7 +50,8 @@ async def generate_interview_prep(
     company_name: str = Form(...),
     role_title: str = Form(""),
     jd_text: str = Form(""),
-    providers_json: str = Form(""),
+    providers: str = Form(""),  # JSON: [{"name": "groq", "model": "..."}]
+    providers_json: str = Form(""),  # DEPRECATED — rejected with 422
     db: AsyncSession = Depends(get_db),
     user: User = Depends(get_current_user),
 ):
@@ -67,13 +70,13 @@ async def generate_interview_prep(
     wh_entries = list(wh_result.scalars().all())
     work_history_text = "\n\n".join(e.to_text_block() for e in wh_entries)
 
-    # Parse providers list
-    providers_list: list[dict] = []
-    if providers_json.strip():
-        try:
-            providers_list = _json.loads(providers_json)
-        except Exception:
-            logger.warning("interview-prep: invalid providers_json")
+    # Issue #197 — server-side key resolution; the client sends only
+    # ``{name, model}``. ``providers_json`` (legacy) is rejected by
+    # ``_resolve_providers`` with a 422.
+    providers_list_wrapped: list[dict] = await _resolve_providers(
+        providers, db, user, providers_json=providers_json
+    )
+    providers_list: list[dict] = _expose_providers_for_gateway(providers_list_wrapped)
 
     user_prompt = f"""Candidate work history:
 {work_history_text or "Not provided."}

--- a/backend/app/services/user_provider_configs.py
+++ b/backend/app/services/user_provider_configs.py
@@ -1,0 +1,173 @@
+r"""
+Server-side provider key resolution (Issue #197).
+
+Single resolver function ``resolve_decrypted_key`` looks up a user's stored
+provider config row, decrypts the API key in-memory, and returns it wrapped
+in a ``DecryptedKey`` value type.
+
+Why the wrapper?
+----------------
+Defence in depth: if a caller accidentally writes
+``logger.info(f"key={key}")`` the plaintext must never reach the log sink.
+``DecryptedKey`` overrides both ``__repr__`` and ``__str__`` to emit
+``"[REDACTED]"``, and the only way to obtain the raw string is via the
+explicit ``.expose()`` method. Callers therefore opt-in to leak risk
+exactly at the point where they hand the secret to ``httpx`` / the LLM
+gateway, and grep can audit every ``.expose()`` site.
+
+Contract
+--------
+* ``resolve_decrypted_key(user_id, provider_name, db)`` returns
+  ``DecryptedKey | None``. ``None`` means: no row, empty stored key, or
+  decryption failed. Callers MUST treat ``None`` as "this provider is not
+  configured server-side".
+* ``DecryptedKey(...)`` is immutable; reuse a single instance per call.
+* ``DecryptedKey.expose()`` is the only sanctioned way to read the
+  plaintext. It is documented as a leak-risk boundary; auditors should
+  ``grep -n "\.expose()"`` to enumerate every site.
+
+Issue #197 — extension/client no longer transmits provider API keys on
+every generation request. The client sends ``{name, model}`` only and the
+backend resolves the key from ``user_provider_configs`` via this module.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from loguru import logger
+from sqlalchemy import select
+
+from app.models.user_provider_config import UserProviderConfig
+from app.utils.encryption import decrypt_value
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@dataclass(frozen=True)
+class DecryptedKey:
+    """Opaque wrapper around a decrypted API key.
+
+    The plaintext is held in ``_value`` (private by convention). Both
+    ``repr()`` and ``str()`` return ``"[REDACTED]"`` so an accidental
+    ``logger.info(f"key={key}")`` cannot leak the secret. Use
+    :py:meth:`expose` exactly at the boundary that hands the key to the
+    LLM provider HTTP call.
+    """
+
+    _value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self._value, str):  # pragma: no cover - defensive
+            raise TypeError("DecryptedKey wraps str only")
+        if not self._value:
+            raise ValueError("DecryptedKey rejects empty plaintext — use None instead")
+
+    # -- Redaction --
+
+    def __repr__(self) -> str:  # noqa: D401 - documented in class docstring
+        return "[REDACTED]"
+
+    def __str__(self) -> str:  # noqa: D401 - documented in class docstring
+        return "[REDACTED]"
+
+    def __format__(self, format_spec: str) -> str:
+        # f"{key}" → "[REDACTED]" regardless of format spec.
+        return "[REDACTED]"
+
+    # -- Sanctioned escape hatch --
+
+    def expose(self) -> str:
+        """Return the plaintext API key.
+
+        SECURITY: every call site of ``.expose()`` is a leak-risk boundary.
+        Only call this at the HTTP boundary that hands the key to the LLM
+        provider. Never log or interpolate the return value.
+        """
+        return self._value
+
+
+async def resolve_decrypted_key(
+    user_id: uuid.UUID,
+    provider_name: str,
+    db: AsyncSession,
+) -> DecryptedKey | None:
+    """Look up + decrypt the user's stored key for ``provider_name``.
+
+    Returns ``None`` when:
+    * no row exists for ``(user_id, provider_name)``
+    * the row exists but ``encrypted_api_key`` is empty
+    * decryption raises (corrupted ciphertext or Fernet key mismatch)
+
+    Callers MUST treat ``None`` as "this provider is not configured" and
+    skip the provider entirely.
+    """
+    stmt = select(UserProviderConfig).where(
+        UserProviderConfig.user_id == user_id,
+        UserProviderConfig.provider_name == provider_name,
+    )
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None or not row.encrypted_api_key:
+        return None
+    try:
+        plaintext = decrypt_value(row.encrypted_api_key)
+    except Exception:
+        # decrypt_value already logged the failure (without echoing the
+        # ciphertext). Treat decryption failure as "no key" so the caller
+        # falls through to other providers / keyword fallback.
+        logger.warning(
+            "resolve_decrypted_key: decrypt failed for user={} provider={}",
+            user_id,
+            provider_name,
+        )
+        return None
+    if not plaintext:
+        return None
+    return DecryptedKey(plaintext)
+
+
+async def resolve_user_providers(
+    user_id: uuid.UUID,
+    requested: list[dict],
+    db: AsyncSession,
+) -> list[dict]:
+    """Resolve client-supplied ``[{name, model}, ...]`` into provider dicts
+    enriched with decrypted API keys (still wrapped in ``DecryptedKey``).
+
+    Output schema::
+
+        [
+            {"name": "anthropic", "model": "claude-...", "api_key": DecryptedKey},
+            ...
+        ]
+
+    Providers without a server-side key are silently dropped. Ollama is a
+    special case — it needs no API key, so it passes through with
+    ``api_key=None``.
+
+    Callers should call ``entry["api_key"].expose()`` exactly when
+    handing the key to the LLM provider HTTP call.
+    """
+    enriched: list[dict] = []
+    for entry in requested:
+        name = (entry.get("name") or "").strip()
+        model = (entry.get("model") or "").strip()
+        if not name:
+            continue
+        if name == "ollama":
+            enriched.append({"name": name, "model": model, "api_key": None})
+            continue
+        key = await resolve_decrypted_key(user_id, name, db)
+        if key is None:
+            logger.debug(
+                "resolve_user_providers: no server-side key for user={} provider={} — skipping",
+                user_id,
+                name,
+            )
+            continue
+        enriched.append({"name": name, "model": model, "api_key": key})
+    return enriched

--- a/backend/app/services/user_provider_configs.py
+++ b/backend/app/services/user_provider_configs.py
@@ -56,9 +56,27 @@ class DecryptedKey:
     ``logger.info(f"key={key}")`` cannot leak the secret. Use
     :py:meth:`expose` exactly at the boundary that hands the key to the
     LLM provider HTTP call.
+
+    Subclassing is forbidden — a child class could override ``__repr__``
+    (or any redaction method) to leak the plaintext, defeating the
+    contract that every interpolation site is safe. See
+    :py:meth:`__init_subclass__`.
     """
 
     _value: str
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        # Defence in depth. ``@dataclass(frozen=True)`` only blocks
+        # attribute *mutation*; Python still permits a subclass to
+        # override ``__repr__``, ``__str__``, ``__format__`` and
+        # re-introduce a leak. Refuse to construct the subclass at
+        # class-creation time so any such attempt fails loudly during
+        # import rather than at the leak site.
+        raise TypeError(
+            "DecryptedKey is final and may not be subclassed. "
+            "Use composition (wrap a DecryptedKey instance) instead so "
+            "the redaction contract is preserved."
+        )
 
     def __post_init__(self) -> None:
         if not isinstance(self._value, str):  # pragma: no cover - defensive

--- a/backend/app/services/user_provider_configs.py
+++ b/backend/app/services/user_provider_configs.py
@@ -42,6 +42,7 @@ from sqlalchemy import select
 
 from app.models.user_provider_config import UserProviderConfig
 from app.utils.encryption import decrypt_value
+from app.utils.log_safety import sanitize_log_value
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -137,10 +138,13 @@ async def resolve_decrypted_key(
         # decrypt_value already logged the failure (without echoing the
         # ciphertext). Treat decryption failure as "no key" so the caller
         # falls through to other providers / keyword fallback.
+        # ``provider_name`` originates from a request form field (or the
+        # legacy ``providers_json`` payload) so it is attacker controlled.
+        # Sanitize CRLF + cap length to defuse log forging (CWE-117).
         logger.warning(
             "resolve_decrypted_key: decrypt failed for user={} provider={}",
             user_id,
-            provider_name,
+            sanitize_log_value(provider_name),
         )
         return None
     if not plaintext:
@@ -215,10 +219,12 @@ async def resolve_user_providers(
                 raise ProviderNotConfiguredError(name)
             # Promoted from DEBUG → INFO so the silent drop is visible at
             # the default log level (Issue #197 P1-F observability gap).
+            # ``name`` comes from the client payload — sanitize before
+            # interpolating to defuse CRLF log forging (CWE-117).
             logger.info(
                 "provider_skipped user={} provider={} reason=no_server_key",
                 user_id,
-                name,
+                sanitize_log_value(name),
             )
             continue
         enriched.append({"name": name, "model": model, "api_key": key})

--- a/backend/app/services/user_provider_configs.py
+++ b/backend/app/services/user_provider_configs.py
@@ -130,10 +130,28 @@ async def resolve_decrypted_key(
     return DecryptedKey(plaintext)
 
 
+class ProviderNotConfiguredError(Exception):
+    """Raised when a client-requested provider has no server-side key.
+
+    The endpoint translates this into HTTP 400 with the missing provider
+    name in the detail. Distinct from a generic 422 so the extension can
+    surface a specific "Add the API key in Options" prompt to the user.
+    """
+
+    def __init__(self, provider_name: str) -> None:
+        self.provider_name = provider_name
+        super().__init__(
+            f"Provider '{provider_name}' is not configured. "
+            "Add the API key in Options before generating."
+        )
+
+
 async def resolve_user_providers(
     user_id: uuid.UUID,
     requested: list[dict],
     db: AsyncSession,
+    *,
+    strict: bool = False,
 ) -> list[dict]:
     """Resolve client-supplied ``[{name, model}, ...]`` into provider dicts
     enriched with decrypted API keys (still wrapped in ``DecryptedKey``).
@@ -145,9 +163,21 @@ async def resolve_user_providers(
             ...
         ]
 
-    Providers without a server-side key are silently dropped. Ollama is a
-    special case — it needs no API key, so it passes through with
+    Ollama is the only keyless provider — it passes through with
     ``api_key=None``.
+
+    Modes
+    -----
+    * ``strict=False`` (default, used by the empty-list server fallback):
+      providers without a server-side key are dropped with an INFO log so
+      operators can see which configurations are missing keys. The caller
+      decides what to do with an empty result.
+    * ``strict=True`` (used when the client explicitly named providers):
+      the first provider whose row is missing / un-decryptable raises
+      :class:`ProviderNotConfiguredError`. The endpoint catches it and
+      returns HTTP 400 with the provider name in the detail. This is the
+      contract documented in Issue #197 — "client list resolves to zero
+      providers" must surface as a loud error, not a silent fallback.
 
     Callers should call ``entry["api_key"].expose()`` exactly when
     handing the key to the LLM provider HTTP call.
@@ -163,8 +193,12 @@ async def resolve_user_providers(
             continue
         key = await resolve_decrypted_key(user_id, name, db)
         if key is None:
-            logger.debug(
-                "resolve_user_providers: no server-side key for user={} provider={} — skipping",
+            if strict:
+                raise ProviderNotConfiguredError(name)
+            # Promoted from DEBUG → INFO so the silent drop is visible at
+            # the default log level (Issue #197 P1-F observability gap).
+            logger.info(
+                "provider_skipped user={} provider={} reason=no_server_key",
                 user_id,
                 name,
             )

--- a/backend/app/utils/log_safety.py
+++ b/backend/app/utils/log_safety.py
@@ -1,0 +1,35 @@
+"""Log-line sanitization helpers (Issue #197 P2 round-3/round-4).
+
+Anywhere a user-controlled value (``User-Agent`` header, ``provider_name``
+form field, etc.) is interpolated into a structured log line, a
+malicious client can inject CRLF to forge a second, attacker-shaped log
+line ("log forging" — CWE-117). We defuse that class of bug by escaping
+``\\r`` / ``\\n`` to literal two-character sequences and capping the
+result at 200 characters so a pathological 64KB header cannot blow up
+the log pipeline either.
+
+Use :func:`sanitize_log_value` at every interpolation site whose source
+crosses the trust boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_MAX_LOG_VALUE_LEN = 200
+
+
+def sanitize_log_value(v: Any) -> str:
+    """Escape CRLF and cap length on a value before logging.
+
+    Accepts any type — ``None`` becomes ``""`` and non-string values are
+    coerced via ``str()`` first. Returns the sanitized string ready for
+    interpolation.
+    """
+    if v is None:
+        return ""
+    if not isinstance(v, str):
+        v = str(v)
+    if not v:
+        return ""
+    return v.replace("\r", "\\r").replace("\n", "\\n")[:_MAX_LOG_VALUE_LEN]

--- a/backend/tests/test_vault_generate_rag.py
+++ b/backend/tests/test_vault_generate_rag.py
@@ -72,6 +72,13 @@ async def test_generate_resume_calls_rag_and_passes_context():
         ),
         patch("app.routers.vault.score_resume", return_value=None),
         patch("app.routers.vault.build_tfidf_vector", return_value=[]),
+        # Issue #197: resolve_decrypted_key is called by generate_resume.
+        # Stub it so the test doesn't need a real DB row.
+        patch(
+            "app.services.user_provider_configs.resolve_decrypted_key",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
         # Prevent actual DB insert
         patch.object(mock_db, "add"),
         patch.object(mock_db, "commit", new_callable=AsyncMock),
@@ -95,8 +102,8 @@ async def test_generate_resume_calls_rag_and_passes_context():
             work_history_text="Worked at Acme.",
             education_text="B.S. CS",
             llm_provider="mock",
-            llm_api_key="test-key",
             ollama_model="llama3.1:8b",
+            providers_json="",  # Issue #197 — legacy field, kept blank
             base_resume_id=None,
             db=mock_db,
             user=mock_user,
@@ -146,6 +153,12 @@ async def test_generate_resume_empty_rag_context_forwarded():
         ),
         patch("app.routers.vault.score_resume", return_value=None),
         patch("app.routers.vault.build_tfidf_vector", return_value=[]),
+        # Issue #197: resolve_decrypted_key is called by generate_resume.
+        patch(
+            "app.services.user_provider_configs.resolve_decrypted_key",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
         patch.object(mock_db, "add"),
         patch.object(mock_db, "commit", new_callable=AsyncMock),
         patch.object(mock_db, "refresh", new_callable=AsyncMock),
@@ -167,8 +180,8 @@ async def test_generate_resume_empty_rag_context_forwarded():
             work_history_text="Worked at Beta Corp.",
             education_text="M.S. CS",
             llm_provider="mock",
-            llm_api_key="test-key",
             ollama_model="llama3.1:8b",
+            providers_json="",  # Issue #197 — legacy field, kept blank
             base_resume_id=None,
             db=mock_db,
             user=mock_user,

--- a/backend/tests/unit/test_decrypted_key.py
+++ b/backend/tests/unit/test_decrypted_key.py
@@ -1,0 +1,195 @@
+"""Unit tests for the ``DecryptedKey`` wrapper (Issue #197).
+
+The wrapper is defence-in-depth: ``repr(key)``, ``str(key)``, and any
+f-string interpolation must emit ``[REDACTED]`` so an accidental
+``logger.info(f"key={key}")`` cannot leak the plaintext. The only way to
+read the plaintext is via the explicit ``.expose()`` method.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import types
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub app.config / app.models.base so the engine is never created (same
+# pattern as test_user_provider_config.py).
+# ---------------------------------------------------------------------------
+for _mod in ("app.config",):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = types.ModuleType(_mod)
+
+import app.config as _cfg  # noqa: E402
+
+if not hasattr(_cfg, "settings"):
+    _cfg.settings = types.SimpleNamespace(  # type: ignore[attr-defined]
+        DATABASE_URL="postgresql+asyncpg://x:y@localhost/z",
+        DB_PASSWORD=None,
+        DB_POOL_SIZE=5,
+        DB_MAX_OVERFLOW=10,
+        DB_ECHO=False,
+        DB_SSL_REQUIRE=False,
+        ENVIRONMENT="test",
+        FERNET_KEY="",
+        is_development=False,
+    )
+
+import sqlalchemy as _sa  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncAttrs  # noqa: E402
+from sqlalchemy.orm import DeclarativeBase  # noqa: E402
+
+_base_stub = types.ModuleType("app.models.base")
+
+
+class _Base(AsyncAttrs, DeclarativeBase):
+    pass
+
+
+class _TimestampMixin:
+    from datetime import datetime
+
+    from sqlalchemy import DateTime, func
+    from sqlalchemy.orm import Mapped, mapped_column
+
+    created_at: Mapped[datetime] = mapped_column(
+        _sa.DateTime(timezone=True), server_default=_sa.func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        _sa.DateTime(timezone=True), server_default=_sa.func.now(), nullable=False
+    )
+
+
+_base_stub.Base = _Base  # type: ignore[attr-defined]
+_base_stub.TimestampMixin = _TimestampMixin  # type: ignore[attr-defined]
+sys.modules["app.models.base"] = _base_stub
+
+from app.services.user_provider_configs import DecryptedKey  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Redaction tests — the wrapper's core invariant.
+# ---------------------------------------------------------------------------
+
+
+SECRET = "sk-ant-this-must-never-appear-in-logs-or-reprs"
+
+
+def test_repr_is_redacted():
+    """``repr(key)`` returns ``[REDACTED]`` — never the plaintext."""
+    key = DecryptedKey(SECRET)
+    assert repr(key) == "[REDACTED]"
+    assert SECRET not in repr(key)
+
+
+def test_str_is_redacted():
+    """``str(key)`` returns ``[REDACTED]`` — never the plaintext."""
+    key = DecryptedKey(SECRET)
+    assert str(key) == "[REDACTED]"
+    assert SECRET not in str(key)
+
+
+def test_f_string_interpolation_is_redacted():
+    """``f"key: {key}"`` produces ``[REDACTED]`` — defence-in-depth."""
+    key = DecryptedKey(SECRET)
+    rendered = f"key: {key}"
+    assert rendered == "key: [REDACTED]"
+    assert SECRET not in rendered
+
+
+def test_format_with_spec_is_redacted():
+    """``f"{key:>30}"`` also redacts (no format spec leaks the secret)."""
+    key = DecryptedKey(SECRET)
+    rendered = f"{key:>30}"
+    assert SECRET not in rendered
+    assert "[REDACTED]" in rendered
+
+
+def test_percent_format_is_redacted():
+    """``"%s" % key`` also redacts."""
+    key = DecryptedKey(SECRET)
+    rendered = "%s" % key  # noqa: UP031 - explicitly testing % formatting
+    assert rendered == "[REDACTED]"
+    assert SECRET not in rendered
+
+
+def test_str_format_is_redacted():
+    """``"{0}".format(key)`` also redacts."""
+    key = DecryptedKey(SECRET)
+    rendered = "{0}".format(key)  # noqa: UP030, UP032 - explicitly testing str.format
+    assert SECRET not in rendered
+
+
+def test_expose_returns_plaintext():
+    """``.expose()`` is the only sanctioned plaintext escape hatch."""
+    key = DecryptedKey(SECRET)
+    assert key.expose() == SECRET
+
+
+def test_expose_is_only_plaintext_path():
+    """No __str__ / __repr__ / __format__ path leaks the secret —
+    only ``.expose()`` does."""
+    key = DecryptedKey(SECRET)
+    sinks = (
+        repr(key),
+        str(key),
+        f"{key}",
+        f"{key:>50}",
+        "{0}".format(key),  # noqa: UP030,UP032 - explicitly testing str.format
+        "%s" % key,  # noqa: UP031 - explicitly testing % formatting
+        "%r" % key,  # noqa: UP031 - explicitly testing % formatting
+    )
+    for sink in sinks:
+        assert SECRET not in sink, f"plaintext leaked via: {sink!r}"
+    # Only the sanctioned method exposes it.
+    assert key.expose() == SECRET
+
+
+def test_rejects_empty_plaintext():
+    """An empty string is meaningless as an API key — wrapper rejects it."""
+    with pytest.raises(ValueError):
+        DecryptedKey("")
+
+
+def test_logger_interpolation_does_not_leak():
+    """A typical ``logger.info(f"key={key}")`` mistake produces ``[REDACTED]``.
+
+    Wires loguru → a captured sink so we can assert on the rendered line.
+    Some sibling tests in this directory replace ``loguru.logger`` with a
+    ``SimpleNamespace`` of no-op callables, so we restore the real one
+    locally to ensure deterministic behaviour regardless of test order.
+    """
+    import loguru as _loguru_mod
+    from loguru._logger import Core as _Core
+    from loguru._logger import Logger as _Logger
+
+    saved = _loguru_mod.logger
+    fresh = _Logger(_Core(), None, 0, False, False, False, False, True, [], {})
+    _loguru_mod.logger = fresh
+    try:
+        sink = io.StringIO()
+        handler_id = fresh.add(sink, format="{message}", level="DEBUG")
+        try:
+            key = DecryptedKey(SECRET)
+            # The classic mistake: an f-string in a log line.
+            fresh.info(f"key={key}")
+            # Also try loguru's positional formatter.
+            fresh.info("key2={}", key)
+            output = sink.getvalue()
+        finally:
+            fresh.remove(handler_id)
+    finally:
+        _loguru_mod.logger = saved
+
+    assert SECRET not in output
+    assert "[REDACTED]" in output
+
+
+def test_dataclass_is_frozen():
+    """Reassigning the underlying value must raise — keys are immutable."""
+    from dataclasses import FrozenInstanceError
+
+    key = DecryptedKey(SECRET)
+    with pytest.raises(FrozenInstanceError):
+        key._value = "tampered"  # type: ignore[misc]

--- a/backend/tests/unit/test_resolve_decrypted_key.py
+++ b/backend/tests/unit/test_resolve_decrypted_key.py
@@ -387,3 +387,100 @@ async def test_resolve_decrypted_key_isolates_users_in_real_sqlite_db():
         assert alice_key.expose() != bob_key.expose()
     finally:
         await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Issue #197 P2 round-4 — log sanitization for user-controlled provider
+# names. ``provider_name`` arrives via a request form field (or the
+# legacy ``providers_json`` payload) and is then interpolated into
+# structured log lines. A malicious value containing CRLF could forge a
+# second, attacker-shaped log line (CWE-117 "log forging"). The
+# ``sanitize_log_value`` helper escapes ``\r`` / ``\n`` to literal
+# two-character sequences and caps length at 200 chars. These tests pin
+# the contract using a loguru sink capture so a future refactor that
+# drops ``sanitize_log_value()`` fails loudly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_decrypted_key_sanitizes_provider_name_in_decrypt_failure_log():
+    """Decrypt-failure path must escape CRLF in the logged provider name."""
+    from loguru import logger as _loguru_logger
+
+    user_id = uuid.uuid4()
+    row = MagicMock()
+    row.encrypted_api_key = "garbage-ciphertext"  # forces decrypt to fail
+    db = _mock_db_with_row(row)
+
+    captured: list[str] = []
+    sink_id = _loguru_logger.add(
+        lambda msg: captured.append(str(msg)),
+        level="WARNING",
+        format="{message}",
+    )
+    try:
+        malicious = "groq\r\nLevel:INFO Message:FAKE LOG"
+        key = await resolve_decrypted_key(user_id, malicious, db)
+    finally:
+        _loguru_logger.remove(sink_id)
+
+    assert key is None
+    joined = "\n".join(captured)
+    # Sanitized form is present.
+    assert "groq\\r\\nLevel:INFO Message:FAKE LOG" in joined
+    # And the raw CRLF never made it into the sink.
+    assert "groq\r\n" not in joined
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_providers_sanitizes_provider_name_in_skip_log():
+    """``resolve_user_providers`` strict=False path must escape CRLF in
+    the ``provider_skipped`` log line."""
+    from loguru import logger as _loguru_logger
+
+    user_id = uuid.uuid4()
+    db = AsyncMock()
+    captured: list[str] = []
+    sink_id = _loguru_logger.add(
+        lambda msg: captured.append(str(msg)),
+        level="INFO",
+        format="{message}",
+    )
+    try:
+        malicious = "openai\r\nLevel:CRITICAL Message:pwned"
+        with patch(
+            "app.services.user_provider_configs.resolve_decrypted_key",
+            return_value=None,
+        ):
+            enriched = await resolve_user_providers(
+                user_id,
+                [{"name": malicious, "model": "gpt-4o"}],
+                db,
+                strict=False,
+            )
+    finally:
+        _loguru_logger.remove(sink_id)
+
+    assert enriched == []
+    joined = "\n".join(captured)
+    assert "openai\\r\\nLevel:CRITICAL Message:pwned" in joined
+    assert "openai\r\n" not in joined
+
+
+def test_sanitize_log_value_helper_contract():
+    """The shared util handles None, non-strings, CRLF, and long input."""
+    from app.utils.log_safety import sanitize_log_value
+
+    # None and empty → empty string.
+    assert sanitize_log_value(None) == ""
+    assert sanitize_log_value("") == ""
+
+    # Non-string types are coerced via str().
+    assert sanitize_log_value(42) == "42"
+
+    # CRLF escaped to literal two-character sequences.
+    assert sanitize_log_value("a\r\nb") == "a\\r\\nb"
+
+    # 200-char cap.
+    long = "x" * 500
+    assert len(sanitize_log_value(long)) == 200

--- a/backend/tests/unit/test_resolve_decrypted_key.py
+++ b/backend/tests/unit/test_resolve_decrypted_key.py
@@ -1,0 +1,242 @@
+"""Unit tests for ``resolve_decrypted_key`` and ``resolve_user_providers``.
+
+Issue #197 — the resolver is the single seam through which a user's
+encrypted API key is decrypted in-memory. Everything else in the stack
+should go through it.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Stub config so importing the model doesn't try to spin up an engine.
+if "app.config" not in sys.modules:
+    sys.modules["app.config"] = types.ModuleType("app.config")
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+import app.config as _cfg  # noqa: E402
+
+# Generate a stable Fernet key for the test process if the env var is
+# unset. The encryption util reads ``settings.FERNET_KEY`` lazily so we
+# can patch it on the settings singleton.
+_TEST_FERNET = Fernet.generate_key().decode()
+os.environ.setdefault("FERNET_KEY", _TEST_FERNET)
+
+if not hasattr(_cfg, "settings"):
+    _cfg.settings = types.SimpleNamespace(  # type: ignore[attr-defined]
+        DATABASE_URL="postgresql+asyncpg://x:y@localhost/z",
+        DB_PASSWORD=None,
+        DB_POOL_SIZE=5,
+        DB_MAX_OVERFLOW=10,
+        DB_ECHO=False,
+        DB_SSL_REQUIRE=False,
+        ENVIRONMENT="test",
+        FERNET_KEY=_TEST_FERNET,
+        is_development=False,
+    )
+else:
+    _cfg.settings.FERNET_KEY = _TEST_FERNET  # type: ignore[attr-defined]
+
+import sqlalchemy as _sa  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncAttrs  # noqa: E402
+from sqlalchemy.orm import DeclarativeBase  # noqa: E402
+
+_base_stub = types.ModuleType("app.models.base")
+
+
+class _Base(AsyncAttrs, DeclarativeBase):
+    pass
+
+
+class _TimestampMixin:
+    from datetime import datetime
+
+    from sqlalchemy import DateTime, func
+    from sqlalchemy.orm import Mapped, mapped_column
+
+    created_at: Mapped[datetime] = mapped_column(
+        _sa.DateTime(timezone=True), server_default=_sa.func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        _sa.DateTime(timezone=True), server_default=_sa.func.now(), nullable=False
+    )
+
+
+_base_stub.Base = _Base  # type: ignore[attr-defined]
+_base_stub.TimestampMixin = _TimestampMixin  # type: ignore[attr-defined]
+sys.modules["app.models.base"] = _base_stub
+
+from app.services.user_provider_configs import (  # noqa: E402
+    DecryptedKey,
+    resolve_decrypted_key,
+    resolve_user_providers,
+)
+from app.utils.encryption import encrypt_value  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _ensure_fernet_key():
+    """Pin ``FERNET_KEY`` before each test.
+
+    ``app.utils.encryption`` binds ``settings`` at import time via
+    ``from app.config import settings`` — so it is sensitive to anything
+    that swaps ``app.config.settings`` after the encryption module was
+    imported. We patch BOTH bindings.
+    """
+    import app.config as _live_cfg
+    import app.utils.encryption as _enc
+
+    saved_cfg = _live_cfg.settings
+    saved_enc_settings = _enc.settings
+
+    pinned = types.SimpleNamespace(FERNET_KEY=_TEST_FERNET)
+    _live_cfg.settings = pinned  # type: ignore[attr-defined]
+    _enc.settings = pinned  # type: ignore[attr-defined]
+    try:
+        yield
+    finally:
+        _live_cfg.settings = saved_cfg  # type: ignore[attr-defined]
+        _enc.settings = saved_enc_settings  # type: ignore[attr-defined]
+
+
+def _mock_db_with_row(row):
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = row
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    return mock_db
+
+
+@pytest.mark.asyncio
+async def test_resolve_decrypted_key_returns_wrapped_secret():
+    """Happy path: row exists with encrypted key → return DecryptedKey."""
+    user_id = uuid.uuid4()
+    row = MagicMock()
+    row.encrypted_api_key = encrypt_value("sk-ant-secret-12345")
+    db = _mock_db_with_row(row)
+
+    key = await resolve_decrypted_key(user_id, "anthropic", db)
+
+    assert isinstance(key, DecryptedKey)
+    assert key.expose() == "sk-ant-secret-12345"
+    # And critically — no plaintext in repr/str.
+    assert "sk-ant-secret-12345" not in repr(key)
+    assert "sk-ant-secret-12345" not in str(key)
+
+
+@pytest.mark.asyncio
+async def test_resolve_decrypted_key_returns_none_when_row_missing():
+    user_id = uuid.uuid4()
+    db = _mock_db_with_row(None)
+
+    key = await resolve_decrypted_key(user_id, "openai", db)
+    assert key is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_decrypted_key_returns_none_for_empty_stored_key():
+    user_id = uuid.uuid4()
+    row = MagicMock()
+    row.encrypted_api_key = ""
+    db = _mock_db_with_row(row)
+
+    key = await resolve_decrypted_key(user_id, "openai", db)
+    assert key is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_decrypted_key_returns_none_on_decrypt_failure():
+    """Corrupted ciphertext must NOT propagate — return None and log."""
+    user_id = uuid.uuid4()
+    row = MagicMock()
+    row.encrypted_api_key = "this-is-not-valid-fernet-ciphertext"
+    db = _mock_db_with_row(row)
+
+    key = await resolve_decrypted_key(user_id, "openai", db)
+    assert key is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_providers_enriches_with_decrypted_keys():
+    user_id = uuid.uuid4()
+    encrypted = encrypt_value("gsk_real_groq_key")
+
+    async def fake_resolve(uid, name, db):
+        if name == "groq":
+            return DecryptedKey("gsk_real_groq_key")
+        return None
+
+    db = AsyncMock()
+    with patch(
+        "app.services.user_provider_configs.resolve_decrypted_key",
+        side_effect=fake_resolve,
+    ):
+        enriched = await resolve_user_providers(
+            user_id,
+            [
+                {"name": "groq", "model": "llama-3.3-70b-versatile"},
+                {"name": "openai", "model": "gpt-4o-mini"},  # no key configured
+            ],
+            db,
+        )
+
+    # Only groq survives — openai has no server-side key.
+    assert len(enriched) == 1
+    assert enriched[0]["name"] == "groq"
+    assert enriched[0]["model"] == "llama-3.3-70b-versatile"
+    assert isinstance(enriched[0]["api_key"], DecryptedKey)
+    assert enriched[0]["api_key"].expose() == "gsk_real_groq_key"
+    # Belt-and-braces: encrypted ciphertext also never appears in repr.
+    assert encrypted not in repr(enriched[0]["api_key"])
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_providers_passes_ollama_without_key():
+    """Ollama is local — needs no API key, so passes through with api_key=None."""
+    user_id = uuid.uuid4()
+    db = AsyncMock()
+
+    enriched = await resolve_user_providers(
+        user_id,
+        [{"name": "ollama", "model": "llama3.1:8b"}],
+        db,
+    )
+
+    assert len(enriched) == 1
+    assert enriched[0]["name"] == "ollama"
+    assert enriched[0]["api_key"] is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_providers_drops_unknown_keyless_providers():
+    user_id = uuid.uuid4()
+    db = AsyncMock()
+    with patch(
+        "app.services.user_provider_configs.resolve_decrypted_key",
+        return_value=None,
+    ):
+        enriched = await resolve_user_providers(
+            user_id,
+            [{"name": "openai", "model": "gpt-4o"}],
+            db,
+        )
+    assert enriched == []
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_providers_ignores_blank_name_entries():
+    user_id = uuid.uuid4()
+    db = AsyncMock()
+    enriched = await resolve_user_providers(
+        user_id,
+        [{"name": "", "model": "x"}, {"model": "y"}],
+        db,
+    )
+    assert enriched == []

--- a/backend/tests/unit/test_resolve_decrypted_key.py
+++ b/backend/tests/unit/test_resolve_decrypted_key.py
@@ -305,19 +305,17 @@ async def test_resolve_decrypted_key_query_binds_user_id_and_provider_name():
 
     # WHERE clause references both columns.
     assert "user_id" in rendered_sql, f"user_id missing from WHERE: {rendered_sql}"
-    assert "provider_name" in rendered_sql, (
-        f"provider_name missing from WHERE: {rendered_sql}"
-    )
+    assert "provider_name" in rendered_sql, f"provider_name missing from WHERE: {rendered_sql}"
 
     # And the bound values are exactly what the caller passed — i.e. a
     # mutation that hard-codes a literal user_id would fail here.
     bound_values = list(params.values())
-    assert user_id in bound_values, (
-        f"caller-supplied user_id not bound in statement params: {params}"
-    )
-    assert "anthropic" in bound_values, (
-        f"caller-supplied provider_name not bound in statement params: {params}"
-    )
+    assert (
+        user_id in bound_values
+    ), f"caller-supplied user_id not bound in statement params: {params}"
+    assert (
+        "anthropic" in bound_values
+    ), f"caller-supplied provider_name not bound in statement params: {params}"
 
 
 @pytest.mark.asyncio
@@ -349,9 +347,7 @@ async def test_resolve_decrypted_key_isolates_users_in_real_sqlite_db():
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
     try:
         async with engine.begin() as conn:
-            await conn.run_sync(
-                lambda sync_conn: UserProviderConfig.__table__.create(sync_conn)
-            )
+            await conn.run_sync(lambda sync_conn: UserProviderConfig.__table__.create(sync_conn))
 
         SessionLocal = sessionmaker(  # type: ignore[call-overload]
             engine, class_=AsyncSession, expire_on_commit=False

--- a/backend/tests/unit/test_resolve_decrypted_key.py
+++ b/backend/tests/unit/test_resolve_decrypted_key.py
@@ -243,6 +243,26 @@ async def test_resolve_user_providers_ignores_blank_name_entries():
 
 
 # ---------------------------------------------------------------------------
+# Issue #197 P1-D — DecryptedKey must reject subclassing. A subclass
+# could override ``__repr__`` / ``__str__`` / ``__format__`` to re-leak
+# the plaintext, which would silently defeat the redaction contract.
+# ---------------------------------------------------------------------------
+
+
+def test_decrypted_key_rejects_subclassing():
+    """Defining a subclass of ``DecryptedKey`` must raise TypeError at
+    class-creation time (before any instance leaks)."""
+    with pytest.raises(TypeError) as exc_info:
+
+        class _LeakySub(DecryptedKey):  # noqa: D401 - test only
+            def __repr__(self) -> str:  # pragma: no cover - unreachable
+                return self._value  # would re-leak if class creation succeeded
+
+    # Message names the contract so future readers understand why.
+    assert "final" in str(exc_info.value).lower() or "subclass" in str(exc_info.value).lower()
+
+
+# ---------------------------------------------------------------------------
 # Issue #197 P1-C — SQL predicate must include BOTH user_id and
 # provider_name. A mutation that drops the user_id binding would let
 # Alice's request resolve Bob's stored key — the row-level cross-user

--- a/backend/tests/unit/test_resolve_decrypted_key.py
+++ b/backend/tests/unit/test_resolve_decrypted_key.py
@@ -240,3 +240,134 @@ async def test_resolve_user_providers_ignores_blank_name_entries():
         db,
     )
     assert enriched == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #197 P1-C — SQL predicate must include BOTH user_id and
+# provider_name. A mutation that drops the user_id binding would let
+# Alice's request resolve Bob's stored key — the row-level cross-user
+# isolation only exists in the WHERE clause.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_decrypted_key_query_binds_user_id_and_provider_name():
+    """The compiled statement passed to ``db.execute`` must reference
+    both ``user_id`` and ``provider_name`` in its WHERE clause AND bind
+    the actual values we passed in. If a refactor drops the user_id
+    predicate this test fails — without it, mocked-row tests would
+    happily accept Alice's request returning Bob's row.
+    """
+    from sqlalchemy.sql import Select
+
+    user_id = uuid.uuid4()
+    row = MagicMock()
+    row.encrypted_api_key = encrypt_value("sk-secret")
+    db = _mock_db_with_row(row)
+
+    await resolve_decrypted_key(user_id, "anthropic", db)
+
+    # ``execute`` was called exactly once with the SELECT statement.
+    assert db.execute.await_count == 1
+    stmt = db.execute.await_args[0][0]
+    assert isinstance(stmt, Select), f"expected Select, got {type(stmt).__name__}"
+
+    # Compile with the SQLite dialect (no real DB needed) so we can
+    # inspect the rendered WHERE clause and the bound parameter values.
+    from sqlalchemy.dialects import sqlite
+
+    compiled = stmt.compile(
+        dialect=sqlite.dialect(),
+        compile_kwargs={"literal_binds": False},
+    )
+    rendered_sql = str(compiled).lower()
+    params = compiled.params  # dict of bound param name → value
+
+    # WHERE clause references both columns.
+    assert "user_id" in rendered_sql, f"user_id missing from WHERE: {rendered_sql}"
+    assert "provider_name" in rendered_sql, (
+        f"provider_name missing from WHERE: {rendered_sql}"
+    )
+
+    # And the bound values are exactly what the caller passed — i.e. a
+    # mutation that hard-codes a literal user_id would fail here.
+    bound_values = list(params.values())
+    assert user_id in bound_values, (
+        f"caller-supplied user_id not bound in statement params: {params}"
+    )
+    assert "anthropic" in bound_values, (
+        f"caller-supplied provider_name not bound in statement params: {params}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_decrypted_key_isolates_users_in_real_sqlite_db():
+    """Belt-and-braces over the introspection test above: spin up a real
+    in-memory sqlite engine with the actual ``user_provider_configs``
+    table, insert rows for two distinct users with different encrypted
+    keys, and confirm ``resolve_decrypted_key(alice_id, ...)`` returns
+    Alice's plaintext (never Bob's). If a mutation drops the user_id
+    predicate this test fails because the query returns >1 row and
+    ``scalar_one_or_none`` raises.
+
+    Skipped when ``aiosqlite`` is unavailable — the static-statement
+    introspection test above is the primary guard; this is the
+    end-to-end belt.
+    """
+    pytest.importorskip("aiosqlite")
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
+    # Importing the model also registers it on the shared declarative
+    # ``Base`` we stubbed at the top of this file, so its metadata is
+    # available to create the table.
+    from app.models.user_provider_config import UserProviderConfig
+
+    # The pgvector ``Vector`` column type used elsewhere in the schema is
+    # not portable to sqlite — but ``UserProviderConfig`` itself has no
+    # vector columns so we create only its single table.
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                lambda sync_conn: UserProviderConfig.__table__.create(sync_conn)
+            )
+
+        SessionLocal = sessionmaker(  # type: ignore[call-overload]
+            engine, class_=AsyncSession, expire_on_commit=False
+        )
+
+        alice_id = uuid.uuid4()
+        bob_id = uuid.uuid4()
+
+        async with SessionLocal() as session:
+            session.add_all(
+                [
+                    UserProviderConfig(
+                        user_id=alice_id,
+                        provider_name="anthropic",
+                        encrypted_api_key=encrypt_value("sk-alice"),
+                    ),
+                    UserProviderConfig(
+                        user_id=bob_id,
+                        provider_name="anthropic",
+                        encrypted_api_key=encrypt_value("sk-bob"),
+                    ),
+                ]
+            )
+            await session.commit()
+
+        async with SessionLocal() as session:
+            alice_key = await resolve_decrypted_key(alice_id, "anthropic", session)
+            bob_key = await resolve_decrypted_key(bob_id, "anthropic", session)
+
+        assert alice_key is not None
+        assert bob_key is not None
+        assert alice_key.expose() == "sk-alice"
+        assert bob_key.expose() == "sk-bob"
+        # Critically — the two never collapse to the same value. If a
+        # mutation drops the user_id predicate, ``scalar_one_or_none``
+        # raises ``MultipleResultsFound`` long before this assertion.
+        assert alice_key.expose() != bob_key.expose()
+    finally:
+        await engine.dispose()

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -72,6 +72,36 @@ from app.services.user_provider_configs import (  # noqa: E402
     resolve_user_providers,
 )
 
+
+@pytest.fixture(autouse=True)
+def _default_strict_legacy_rejection():
+    """Force ``ACCEPT_LEGACY_PROVIDERS_JSON`` to ``False`` (strict mode)
+    for every test in this module unless an individual test explicitly
+    flips it to ``True``.
+
+    The production default is now ``True`` (P0-G soft-reject — safe
+    deploy of #197), but the existing endpoint-level tests in this file
+    assert the strict ``422`` contract. Pinning the default to ``False``
+    here keeps the contract assertions meaningful without sprinkling a
+    ``_flip_accept_legacy_flag(False)`` call into every test body. The
+    handful of tests that want soft-reject mode call
+    ``_flip_accept_legacy_flag(True)`` explicitly and the autouse
+    fixture restores the strict default on teardown.
+    """
+    import app.config as _cfg_mod
+    import app.routers.vault._shared as _shared_mod
+
+    bindings = (_cfg_mod, _shared_mod)
+    saved = [(b, getattr(b.settings, "ACCEPT_LEGACY_PROVIDERS_JSON", True)) for b in bindings]
+    for b in bindings:
+        b.settings.ACCEPT_LEGACY_PROVIDERS_JSON = False
+    try:
+        yield
+    finally:
+        for b, prev in saved:
+            b.settings.ACCEPT_LEGACY_PROVIDERS_JSON = prev
+
+
 # ---------------------------------------------------------------------------
 # providers_json rejection (AC 1: 422 with clear error)
 # ---------------------------------------------------------------------------
@@ -812,18 +842,14 @@ async def test_resolve_providers_accept_legacy_flag_uses_legacy_payload():
 
 
 @pytest.mark.asyncio
-async def test_resolve_providers_strict_mode_default_rejects_legacy():
-    """P0-G default — flag off (default), legacy payload is rejected
-    with 422 just like before. We explicitly set the flag to False so
-    test ordering can't leave a previous flip dangling."""
+async def test_resolve_providers_strict_mode_rejects_legacy():
+    """P0-G strict mode — when the operator explicitly flips
+    ``ACCEPT_LEGACY_PROVIDERS_JSON`` to ``False`` (post-rollout), the
+    legacy payload is rejected with 422 just like the original #197
+    contract. The flag is set explicitly here because the default is
+    now ``True`` (soft-reject mode) so a naive deploy is safe."""
     restore_flag = _flip_accept_legacy_flag(False)
     try:
-        import app.routers.vault._shared as _shared_mod
-
-        # Default must be False — the assertion both documents the
-        # default and guards against operator misconfiguration.
-        assert _shared_mod.settings.ACCEPT_LEGACY_PROVIDERS_JSON is False
-
         user = MagicMock()
         user.id = uuid.uuid4()
         db = AsyncMock()
@@ -838,3 +864,19 @@ async def test_resolve_providers_strict_mode_default_rejects_legacy():
         assert exc_info.value.status_code == 422
     finally:
         restore_flag()
+
+
+def test_accept_legacy_providers_json_default_is_true():
+    """P0-G rollout safety — the default value of
+    ``ACCEPT_LEGACY_PROVIDERS_JSON`` MUST be ``True`` so deploying #197
+    does not break older Chrome Web Store installs that still POST the
+    legacy ``providers_json`` field. The operator flips it to ``False``
+    only once rollout adoption is >95%.
+
+    Loaded fresh from the real ``Settings`` class so test ordering /
+    SimpleNamespace stubs cannot mask a regression.
+    """
+    from app.config import Settings
+
+    fresh = Settings()
+    assert fresh.ACCEPT_LEGACY_PROVIDERS_JSON is True

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -1,0 +1,481 @@
+"""Endpoint-level tests for Issue #197.
+
+Verifies the 5 generation endpoint sites:
+* ``providers_json`` is rejected with HTTP 422 (no backward-compat window)
+* the new ``providers`` field (JSON list of ``{name, model}``) is parsed
+* server-side key resolution is invoked, and the decrypted key never
+  appears in any log/response
+
+Endpoints under test:
+1. POST /api/v1/vault/generate/answers
+2. POST /api/v1/vault/generate/answers/trim
+3. POST /api/v1/vault/generate/tailored
+4. POST /api/v1/vault/generate/summary
+5. POST /api/v1/vault/generate/bullets
+6. POST /api/v1/vault/generate/cover-letter
+7. POST /api/v1/vault/interview-prep
+
+(That's 7 endpoint sites total — the brief said 5 but the actual count
+is 7 once you include the helper endpoints in answers.py and generate.py.)
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import types
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Stub config + base before importing the routers (same pattern as the
+# rest of the unit tests).
+if "app.config" not in sys.modules:
+    sys.modules["app.config"] = types.ModuleType("app.config")
+
+from cryptography.fernet import Fernet  # noqa: E402
+
+import app.config as _cfg  # noqa: E402
+
+_TEST_FERNET = Fernet.generate_key().decode()
+os.environ.setdefault("FERNET_KEY", _TEST_FERNET)
+
+if not hasattr(_cfg, "settings"):
+    _cfg.settings = types.SimpleNamespace(  # type: ignore[attr-defined]
+        DATABASE_URL="postgresql+asyncpg://x:y@localhost/z",
+        DB_PASSWORD=None,
+        DB_POOL_SIZE=5,
+        DB_MAX_OVERFLOW=10,
+        DB_ECHO=False,
+        DB_SSL_REQUIRE=False,
+        ENVIRONMENT="test",
+        FERNET_KEY=_TEST_FERNET,
+        is_development=False,
+    )
+else:
+    _cfg.settings.FERNET_KEY = _TEST_FERNET  # type: ignore[attr-defined]
+
+from fastapi import HTTPException  # noqa: E402
+
+from app.routers.vault._shared import (  # noqa: E402
+    _expose_providers_for_gateway,
+    _parse_providers,
+    _reject_providers_json,
+    _resolve_providers,
+)
+from app.services.user_provider_configs import DecryptedKey  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# providers_json rejection (AC 1: 422 with clear error)
+# ---------------------------------------------------------------------------
+
+
+def test_reject_providers_json_raises_422_when_present():
+    """Any non-blank ``providers_json`` value triggers HTTP 422."""
+    with pytest.raises(HTTPException) as exc_info:
+        _reject_providers_json('[{"name":"groq","api_key":"gsk_x"}]')
+    assert exc_info.value.status_code == 422
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail["error"] == "providers_json_removed"
+    # Error message points to the new contract.
+    assert "providers" in detail["message"].lower()
+
+
+def test_reject_providers_json_ignores_empty_string():
+    """Empty / whitespace-only is silently allowed (client sends no field)."""
+    _reject_providers_json("")
+    _reject_providers_json("   ")
+
+
+def test_reject_providers_json_ignores_none():
+    """``None`` is allowed — the caller may opt out by passing the field
+    only when the form actually carries a value."""
+    _reject_providers_json(None or "")
+
+
+# ---------------------------------------------------------------------------
+# providers (new contract) parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_providers_returns_empty_for_blank():
+    assert _parse_providers("") == []
+    assert _parse_providers("   ") == []
+
+
+def test_parse_providers_strips_stray_api_key_field():
+    """If a client mistakenly sends ``api_key`` inside ``providers``,
+    we strip it so it can't slip through to the LLM gateway."""
+    parsed = _parse_providers('[{"name":"groq","model":"llama-3.3-70b","api_key":"gsk_leak"}]')
+    assert parsed == [{"name": "groq", "model": "llama-3.3-70b"}]
+    assert "api_key" not in parsed[0]
+
+
+def test_parse_providers_raises_422_on_invalid_json():
+    with pytest.raises(HTTPException) as exc_info:
+        _parse_providers("not-json")
+    assert exc_info.value.status_code == 422
+
+
+def test_parse_providers_raises_422_on_non_list():
+    with pytest.raises(HTTPException) as exc_info:
+        _parse_providers('{"name": "groq"}')
+    assert exc_info.value.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# _resolve_providers integrates parse + resolve_decrypted_key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_providers_rejects_providers_json_with_422():
+    """Both fields together → 422 wins (no silent fallback)."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_providers(
+            providers="",
+            db=db,
+            user=user,
+            providers_json='[{"name":"groq","api_key":"gsk_x"}]',
+        )
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_resolve_providers_uses_decrypted_key_resolver():
+    """When ``providers`` is supplied, every entry goes through the
+    server-side resolver."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+
+    async def fake_resolve(uid, name, db):
+        return DecryptedKey("gsk_decrypted") if name == "groq" else None
+
+    with patch(
+        "app.services.user_provider_configs.resolve_decrypted_key",
+        side_effect=fake_resolve,
+    ):
+        out = await _resolve_providers(
+            providers='[{"name":"groq","model":"llama-3.3-70b"}]',
+            db=db,
+            user=user,
+        )
+
+    assert len(out) == 1
+    assert out[0]["name"] == "groq"
+    assert isinstance(out[0]["api_key"], DecryptedKey)
+    # And the DecryptedKey wraps the right plaintext.
+    assert out[0]["api_key"].expose() == "gsk_decrypted"
+
+
+# ---------------------------------------------------------------------------
+# _expose_providers_for_gateway: single .expose() boundary
+# ---------------------------------------------------------------------------
+
+
+def test_expose_providers_unwraps_decrypted_keys():
+    """The single sanctioned ``.expose()`` site for downstream gateway calls."""
+    wrapped = [
+        {"name": "groq", "model": "llama-3.3-70b", "api_key": DecryptedKey("gsk_x")},
+        {"name": "ollama", "model": "llama3.1:8b", "api_key": None},
+    ]
+    out = _expose_providers_for_gateway(wrapped)
+    assert out[0] == {"name": "groq", "model": "llama-3.3-70b", "api_key": "gsk_x"}
+    assert out[1] == {"name": "ollama", "model": "llama3.1:8b", "api_key": ""}
+
+
+def test_expose_providers_passthrough_plaintext_str():
+    """Defensive: a plaintext str slips through unchanged (used by tests
+    that build provider dicts directly)."""
+    out = _expose_providers_for_gateway([{"name": "x", "api_key": "plain", "model": ""}])
+    assert out[0]["api_key"] == "plain"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end endpoint smoke tests via direct call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_generate_answers_rejects_providers_json():
+    """Calling ``generate_answers`` with the legacy field raises 422."""
+    from app.routers.vault.answers import generate_answers
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.encrypted_llm_api_key = None
+    user.display_name = "Test"
+    user.email_hash = "abc12345"
+
+    db = AsyncMock()
+    # Work-history query in the endpoint resolves to empty.
+    empty_result = MagicMock()
+    empty_scalars = MagicMock()
+    empty_scalars.all.return_value = []
+    empty_result.scalars.return_value = empty_scalars
+    db.execute = AsyncMock(return_value=empty_result)
+
+    # Patch the retrieval agent to avoid touching real services.
+    with patch("app.routers.vault.answers._agent") as agent_mock:
+        agent_mock.return_value.get_previous_answer = AsyncMock(return_value=None)
+        agent_mock.return_value.get_best_answers_for_question = AsyncMock(return_value=[])
+        with pytest.raises(HTTPException) as exc_info:
+            await generate_answers(
+                question_text="why?",
+                question_category="custom",
+                company_name="ACME",
+                role_title="SWE",
+                jd_text="",
+                work_history_text="",
+                llm_provider="anthropic",
+                ollama_model="llama3.1:8b",
+                providers="",
+                providers_json='[{"name":"groq","api_key":"gsk_leak"}]',
+                max_length=0,
+                category_instructions="",
+                db=db,
+                user=user,
+            )
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_interview_prep_rejects_providers_json():
+    from app.routers.vault.interview import generate_interview_prep
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+    empty_result = MagicMock()
+    empty_scalars = MagicMock()
+    empty_scalars.all.return_value = []
+    empty_result.scalars.return_value = empty_scalars
+    db.execute = AsyncMock(return_value=empty_result)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_interview_prep(
+            company_name="ACME",
+            role_title="SWE",
+            jd_text="",
+            providers="",
+            providers_json='[{"name":"groq","api_key":"gsk_leak"}]',
+            db=db,
+            user=user,
+        )
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_rejects_providers_json():
+    from app.routers.vault.generate import generate_summary_endpoint
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+    empty_result = MagicMock()
+    empty_scalars = MagicMock()
+    empty_scalars.all.return_value = []
+    empty_result.scalars.return_value = empty_scalars
+    db.execute = AsyncMock(return_value=empty_result)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_summary_endpoint(
+            company_name="ACME",
+            role_title="SWE",
+            jd_text="",
+            word_limit=80,
+            candidate_name="Test",
+            providers="",
+            providers_json='[{"name":"groq","api_key":"gsk_leak"}]',
+            db=db,
+            user=user,
+        )
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_generate_bullets_rejects_providers_json():
+    from app.routers.vault.generate import generate_bullets_endpoint
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+    empty_result = MagicMock()
+    empty_scalars = MagicMock()
+    empty_scalars.all.return_value = []
+    empty_result.scalars.return_value = empty_scalars
+    db.execute = AsyncMock(return_value=empty_result)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_bullets_endpoint(
+            company_name="ACME",
+            role_title="SWE",
+            jd_text="",
+            num_bullets=5,
+            target_company_for_context="",
+            providers="",
+            providers_json='[{"name":"groq","api_key":"gsk_leak"}]',
+            db=db,
+            user=user,
+        )
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_generate_cover_letter_rejects_providers_json():
+    from app.routers.vault.generate import generate_cover_letter_endpoint
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+    empty_result = MagicMock()
+    empty_scalars = MagicMock()
+    empty_scalars.all.return_value = []
+    empty_result.scalars.return_value = empty_scalars
+    db.execute = AsyncMock(return_value=empty_result)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_cover_letter_endpoint(
+            company_name="ACME",
+            role_title="SWE",
+            jd_text="",
+            tone="professional",
+            word_limit=400,
+            candidate_name="",
+            providers="",
+            providers_json='[{"name":"groq","api_key":"gsk_leak"}]',
+            db=db,
+            user=user,
+        )
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_trim_answer_rejects_providers_json():
+    """Answer-trim is the 7th endpoint site touched by Issue #197."""
+    from app.routers.vault.answers import trim_answer
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await trim_answer(
+            answer_text="x" * 1000,
+            max_chars=100,
+            providers="",
+            providers_json='[{"name":"groq","api_key":"gsk_leak"}]',
+            db=db,
+            user=user,
+        )
+    assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_tailored_resume_rejects_providers_json():
+    """generate/tailored is the 8th touched endpoint."""
+    from app.routers.vault.generate import generate_tailored_resume
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+    # The endpoint does a SELECT for the resume before parsing providers,
+    # so we need to make that fail-fast. Instead we patch _resolve_providers
+    # to raise the 422 directly when called.
+    base_id = str(uuid.uuid4())
+    # Mock a resume row so the lookup succeeds, then provider parsing
+    # rejects providers_json.
+    resume_row = MagicMock()
+    resume_row.raw_text = "old text"
+    select_result = MagicMock()
+    select_result.scalar_one_or_none.return_value = resume_row
+    empty_scalars = MagicMock()
+    empty_scalars.all.return_value = []
+    wh_result = MagicMock()
+    wh_result.scalars.return_value = empty_scalars
+
+    call_order = [select_result, wh_result]
+
+    async def fake_execute(*args, **kwargs):
+        return call_order.pop(0) if call_order else wh_result
+
+    db.execute = AsyncMock(side_effect=fake_execute)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await generate_tailored_resume(
+            base_resume_id=base_id,
+            jd_text="x",
+            company_name="ACME",
+            role_title="SWE",
+            providers="",
+            providers_json='[{"name":"groq","api_key":"gsk_leak"}]',
+            db=db,
+            user=user,
+        )
+    assert exc_info.value.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Belt-and-braces: a successful resolution never logs the plaintext.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_providers_never_logs_plaintext():
+    """When ``_resolve_providers`` resolves a key, no log line contains
+    the plaintext.
+
+    Some sibling tests permanently replace ``loguru.logger`` with a
+    ``SimpleNamespace`` of no-op callables — we install a fresh, real
+    logger locally so this test runs deterministically.
+    """
+    import loguru as _loguru_mod
+    from loguru._logger import Core as _Core
+    from loguru._logger import Logger as _Logger
+
+    saved = _loguru_mod.logger
+    fresh = _Logger(_Core(), None, 0, False, False, False, False, True, [], {})
+    _loguru_mod.logger = fresh
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+
+    sink = io.StringIO()
+    handler_id = fresh.add(sink, format="{message}", level="DEBUG")
+
+    async def fake_resolve(uid, name, db):
+        # Critically: a noisy resolver that logs the wrapper itself —
+        # should still not leak because DecryptedKey.__repr__ redacts.
+        wrapped = DecryptedKey("sk-PLAINTEXT-LEAK-CHECK")
+        fresh.info(f"resolved: {wrapped}")
+        return wrapped
+
+    try:
+        with patch(
+            "app.services.user_provider_configs.resolve_decrypted_key",
+            side_effect=fake_resolve,
+        ):
+            out = await _resolve_providers(
+                providers='[{"name":"openai","model":"gpt-4o-mini"}]',
+                db=db,
+                user=user,
+            )
+        log_output = sink.getvalue()
+    finally:
+        fresh.remove(handler_id)
+        _loguru_mod.logger = saved
+
+    assert len(out) == 1
+    assert isinstance(out[0]["api_key"], DecryptedKey)
+    # The plaintext must NOT appear in any rendered log line.
+    assert "sk-PLAINTEXT-LEAK-CHECK" not in log_output
+    assert "[REDACTED]" in log_output

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -380,6 +380,58 @@ async def test_trim_answer_rejects_providers_json():
 
 
 @pytest.mark.asyncio
+async def test_trim_answer_cascade_includes_ollama():
+    """Regression — round-1 fix introduced a cascade that skipped any
+    provider with an empty ``api_key`` string. Ollama is keyless (local
+    server) so its plaintext api_key is ``""`` after
+    ``_expose_providers_for_gateway`` — but the cascade must still try it.
+    Asserts ``LLMGateway.generate`` is invoked with ``provider="ollama"``.
+    """
+    from app.routers.vault.answers import trim_answer
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+
+    # _resolve_providers returns wrapped entries. Ollama has api_key=None
+    # which the expose helper renders as "".
+    async def fake_resolve(providers, db, user, *, providers_json=None):
+        return [{"name": "ollama", "model": "llama3.1:8b", "api_key": None}]
+
+    captured: dict = {}
+
+    class FakeGateway:
+        def __init__(self) -> None:
+            pass
+
+        async def generate(self, *, system_prompt, user_prompt, provider, api_key, **kw):
+            captured["provider"] = provider
+            captured["api_key"] = api_key
+            # >20 chars so the cascade accepts it instead of falling through
+            # to hard-truncation.
+            return ("Trimmed answer text that is comfortably above 20 chars.", provider)
+
+    with (
+        patch("app.routers.vault.answers._resolve_providers", side_effect=fake_resolve),
+        patch("app.routers.vault.answers.LLMGateway", FakeGateway),
+    ):
+        out = await trim_answer(
+            answer_text="x" * 1000,
+            max_chars=100,
+            providers='[{"name":"ollama","model":"llama3.1:8b"}]',
+            providers_json="",
+            db=db,
+            user=user,
+        )
+
+    assert captured.get("provider") == "ollama", (
+        "Ollama must be tried in the cascade even when api_key is empty"
+    )
+    assert captured.get("api_key") == ""
+    assert out["provider_used"] == "ollama"
+
+
+@pytest.mark.asyncio
 async def test_tailored_resume_rejects_providers_json():
     """generate/tailored is the 8th touched endpoint."""
     from app.routers.vault.generate import generate_tailored_resume

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -167,16 +167,18 @@ async def test_resolve_providers_raises_400_when_requested_provider_missing_key(
     async def fake_resolve(uid, name, db):
         return None  # no server-side key for any provider
 
-    with patch(
-        "app.services.user_provider_configs.resolve_decrypted_key",
-        side_effect=fake_resolve,
+    with (
+        patch(
+            "app.services.user_provider_configs.resolve_decrypted_key",
+            side_effect=fake_resolve,
+        ),
+        pytest.raises(HTTPException) as exc_info,
     ):
-        with pytest.raises(HTTPException) as exc_info:
-            await _resolve_providers(
-                providers='[{"name":"openai","model":"gpt-4o-mini"}]',
-                db=db,
-                user=user,
-            )
+        await _resolve_providers(
+            providers='[{"name":"openai","model":"gpt-4o-mini"}]',
+            db=db,
+            user=user,
+        )
 
     assert exc_info.value.status_code == 400
     detail = exc_info.value.detail
@@ -198,20 +200,22 @@ async def test_resolve_user_providers_strict_raises_for_missing_key():
     async def fake_resolve(uid, name, db):
         return None
 
-    with patch(
-        "app.services.user_provider_configs.resolve_decrypted_key",
-        side_effect=fake_resolve,
+    with (
+        patch(
+            "app.services.user_provider_configs.resolve_decrypted_key",
+            side_effect=fake_resolve,
+        ),
+        pytest.raises(ProviderNotConfiguredError) as exc_info,
     ):
-        with pytest.raises(ProviderNotConfiguredError) as exc_info:
-            await resolve_user_providers(
-                user_id,
-                [
-                    {"name": "anthropic", "model": "claude-3"},
-                    {"name": "openai", "model": "gpt-4"},
-                ],
-                db,
-                strict=True,
-            )
+        await resolve_user_providers(
+            user_id,
+            [
+                {"name": "anthropic", "model": "claude-3"},
+                {"name": "openai", "model": "gpt-4"},
+            ],
+            db,
+            strict=True,
+        )
 
     assert exc_info.value.provider_name == "anthropic"
 
@@ -518,9 +522,9 @@ async def test_trim_answer_cascade_includes_ollama():
             user=user,
         )
 
-    assert captured.get("provider") == "ollama", (
-        "Ollama must be tried in the cascade even when api_key is empty"
-    )
+    assert (
+        captured.get("provider") == "ollama"
+    ), "Ollama must be tried in the cascade even when api_key is empty"
     assert captured.get("api_key") == ""
     assert out["provider_used"] == "ollama"
 

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -65,7 +65,11 @@ from app.routers.vault._shared import (  # noqa: E402
     _reject_providers_json,
     _resolve_providers,
 )
-from app.services.user_provider_configs import DecryptedKey  # noqa: E402
+from app.services.user_provider_configs import (  # noqa: E402
+    DecryptedKey,
+    ProviderNotConfiguredError,
+    resolve_user_providers,
+)
 
 # ---------------------------------------------------------------------------
 # providers_json rejection (AC 1: 422 with clear error)
@@ -146,6 +150,95 @@ async def test_resolve_providers_rejects_providers_json_with_422():
             providers_json='[{"name":"groq","api_key":"gsk_x"}]',
         )
     assert exc_info.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_resolve_providers_raises_400_when_requested_provider_missing_key():
+    """Issue #197 P1-B — client explicitly names a provider that has no
+    server-side key. The endpoint must return HTTP 400 with the provider
+    name in the detail so the extension can show "Add the API key in
+    Options" rather than silently falling back to keyword-only output.
+    """
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+
+    async def fake_resolve(uid, name, db):
+        return None  # no server-side key for any provider
+
+    with patch(
+        "app.services.user_provider_configs.resolve_decrypted_key",
+        side_effect=fake_resolve,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await _resolve_providers(
+                providers='[{"name":"openai","model":"gpt-4o-mini"}]',
+                db=db,
+                user=user,
+            )
+
+    assert exc_info.value.status_code == 400
+    detail = exc_info.value.detail
+    assert isinstance(detail, dict)
+    assert detail["error"] == "provider_not_configured"
+    assert detail["provider"] == "openai"
+    # The user-facing message must name the missing provider.
+    assert "openai" in detail["message"]
+    assert "Options" in detail["message"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_providers_strict_raises_for_missing_key():
+    """Unit-level mirror of the endpoint contract: strict=True surfaces a
+    ProviderNotConfiguredError with the offending provider name."""
+    user_id = uuid.uuid4()
+    db = AsyncMock()
+
+    async def fake_resolve(uid, name, db):
+        return None
+
+    with patch(
+        "app.services.user_provider_configs.resolve_decrypted_key",
+        side_effect=fake_resolve,
+    ):
+        with pytest.raises(ProviderNotConfiguredError) as exc_info:
+            await resolve_user_providers(
+                user_id,
+                [
+                    {"name": "anthropic", "model": "claude-3"},
+                    {"name": "openai", "model": "gpt-4"},
+                ],
+                db,
+                strict=True,
+            )
+
+    assert exc_info.value.provider_name == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_providers_non_strict_drops_missing():
+    """Default (non-strict) mode keeps the silent-drop behaviour for the
+    server-enumerated fallback path."""
+    user_id = uuid.uuid4()
+    db = AsyncMock()
+
+    async def fake_resolve(uid, name, db):
+        return DecryptedKey("k") if name == "anthropic" else None
+
+    with patch(
+        "app.services.user_provider_configs.resolve_decrypted_key",
+        side_effect=fake_resolve,
+    ):
+        out = await resolve_user_providers(
+            user_id,
+            [
+                {"name": "anthropic", "model": "claude-3"},
+                {"name": "openai", "model": "gpt-4"},
+            ],
+            db,
+            strict=False,
+        )
+    assert [p["name"] for p in out] == ["anthropic"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -700,15 +700,39 @@ def test_reject_providers_json_logs_warning_with_user_and_user_agent():
     assert "AutoApply-Chrome-Ext/1.2.3" in log_output
 
 
+def _flip_accept_legacy_flag(value: bool):
+    """Set ``ACCEPT_LEGACY_PROVIDERS_JSON`` on every binding that callers
+    might consult. Other unit-test files in this repo swap
+    ``app.config.settings`` with a ``SimpleNamespace`` for FERNET_KEY
+    pinning, which leaves ``_shared.py`` holding a stale reference to
+    the original Settings object. Mutating both bindings keeps the
+    test deterministic regardless of import order.
+
+    Returns a no-arg restore callable.
+    """
+    import app.config as _cfg_mod
+    import app.routers.vault._shared as _shared_mod
+
+    bindings = (_cfg_mod, _shared_mod)
+    saved = [(b, getattr(b.settings, "ACCEPT_LEGACY_PROVIDERS_JSON", False)) for b in bindings]
+    for b in bindings:
+        # ``settings`` may be a SimpleNamespace or a Settings instance —
+        # both support attribute assignment.
+        b.settings.ACCEPT_LEGACY_PROVIDERS_JSON = value
+
+    def restore():
+        for b, prev in saved:
+            b.settings.ACCEPT_LEGACY_PROVIDERS_JSON = prev
+
+    return restore
+
+
 def test_reject_providers_json_accept_flag_logs_warning_and_returns():
     """P0-G — when ``ACCEPT_LEGACY_PROVIDERS_JSON`` is True, the
     rejection is suppressed but a WARN line still records the
     user/UA. The function returns None (no raise)."""
-    from app.config import settings as _settings
-
-    saved = _settings.ACCEPT_LEGACY_PROVIDERS_JSON
-    _settings.ACCEPT_LEGACY_PROVIDERS_JSON = True
-    sink, restore = _install_fresh_loguru_sink()
+    restore_flag = _flip_accept_legacy_flag(True)
+    sink, restore_log = _install_fresh_loguru_sink()
     try:
         user_id = uuid.uuid4()
         request = MagicMock()
@@ -723,8 +747,8 @@ def test_reject_providers_json_accept_flag_logs_warning_and_returns():
 
         log_output = sink.getvalue()
     finally:
-        restore()
-        _settings.ACCEPT_LEGACY_PROVIDERS_JSON = saved
+        restore_log()
+        restore_flag()
 
     assert "WARNING" in log_output
     assert "legacy_providers_json_accepted" in log_output
@@ -754,10 +778,7 @@ async def test_resolve_providers_accept_legacy_flag_uses_legacy_payload():
     resolver MUST fall back to the legacy ``providers_json`` payload
     (stripped of api_key) and resolve keys server-side.
     """
-    from app.config import settings as _settings
-
-    saved = _settings.ACCEPT_LEGACY_PROVIDERS_JSON
-    _settings.ACCEPT_LEGACY_PROVIDERS_JSON = True
+    restore_flag = _flip_accept_legacy_flag(True)
     try:
         user = MagicMock()
         user.id = uuid.uuid4()
@@ -780,7 +801,7 @@ async def test_resolve_providers_accept_legacy_flag_uses_legacy_payload():
                 request=request,
             )
     finally:
-        _settings.ACCEPT_LEGACY_PROVIDERS_JSON = saved
+        restore_flag()
 
     assert len(out) == 1
     assert out[0]["name"] == "anthropic"
@@ -793,22 +814,27 @@ async def test_resolve_providers_accept_legacy_flag_uses_legacy_payload():
 @pytest.mark.asyncio
 async def test_resolve_providers_strict_mode_default_rejects_legacy():
     """P0-G default — flag off (default), legacy payload is rejected
-    with 422 just like before."""
-    from app.config import settings as _settings
+    with 422 just like before. We explicitly set the flag to False so
+    test ordering can't leave a previous flip dangling."""
+    restore_flag = _flip_accept_legacy_flag(False)
+    try:
+        import app.routers.vault._shared as _shared_mod
 
-    # Default must be False — the assertion both documents the default
-    # and guards against operator misconfiguration.
-    assert _settings.ACCEPT_LEGACY_PROVIDERS_JSON is False
+        # Default must be False — the assertion both documents the
+        # default and guards against operator misconfiguration.
+        assert _shared_mod.settings.ACCEPT_LEGACY_PROVIDERS_JSON is False
 
-    user = MagicMock()
-    user.id = uuid.uuid4()
-    db = AsyncMock()
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        db = AsyncMock()
 
-    with pytest.raises(HTTPException) as exc_info:
-        await _resolve_providers(
-            providers="",
-            db=db,
-            user=user,
-            providers_json='[{"name":"anthropic","api_key":"sk-LEAK"}]',
-        )
-    assert exc_info.value.status_code == 422
+        with pytest.raises(HTTPException) as exc_info:
+            await _resolve_providers(
+                providers="",
+                db=db,
+                user=user,
+                providers_json='[{"name":"anthropic","api_key":"sk-LEAK"}]',
+            )
+        assert exc_info.value.status_code == 422
+    finally:
+        restore_flag()

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -61,6 +61,7 @@ from fastapi import HTTPException  # noqa: E402
 
 from app.routers.vault._shared import (  # noqa: E402
     _expose_providers_for_gateway,
+    _parse_legacy_providers_json_stripped,
     _parse_providers,
     _reject_providers_json,
     _resolve_providers,
@@ -695,3 +696,115 @@ def test_reject_providers_json_logs_warning_with_user_and_user_agent():
     assert "AutoApply-Chrome-Ext/1.2.3" in log_output
 
 
+def test_reject_providers_json_accept_flag_logs_warning_and_returns():
+    """P0-G — when ``ACCEPT_LEGACY_PROVIDERS_JSON`` is True, the
+    rejection is suppressed but a WARN line still records the
+    user/UA. The function returns None (no raise)."""
+    from app.config import settings as _settings
+
+    saved = _settings.ACCEPT_LEGACY_PROVIDERS_JSON
+    _settings.ACCEPT_LEGACY_PROVIDERS_JSON = True
+    sink, restore = _install_fresh_loguru_sink()
+    try:
+        user_id = uuid.uuid4()
+        request = MagicMock()
+        request.headers = {"user-agent": "AutoApply-Chrome-Ext/0.9.0"}
+
+        # MUST NOT raise.
+        _reject_providers_json(
+            '[{"name":"groq","api_key":"gsk_x"}]',
+            user_id=user_id,
+            request=request,
+        )
+
+        log_output = sink.getvalue()
+    finally:
+        restore()
+        _settings.ACCEPT_LEGACY_PROVIDERS_JSON = saved
+
+    assert "WARNING" in log_output
+    assert "legacy_providers_json_accepted" in log_output
+    assert str(user_id) in log_output
+    assert "AutoApply-Chrome-Ext/0.9.0" in log_output
+
+
+def test_parse_legacy_providers_json_strips_api_key():
+    """Even with the transition flag on, the embedded ``api_key`` must
+    be dropped on the floor — the server resolves keys server-side
+    regardless. A legacy install cannot smuggle a key past us."""
+    parsed = _parse_legacy_providers_json_stripped(
+        '[{"name":"groq","model":"llama-3.3-70b","api_key":"gsk_LEAK"}]'
+    )
+    assert parsed == [{"name": "groq", "model": "llama-3.3-70b"}]
+    for entry in parsed:
+        assert "api_key" not in entry
+        # Belt-and-braces: serialise and check the plaintext is nowhere.
+        import json as _j
+
+        assert "gsk_LEAK" not in _j.dumps(entry)
+
+
+@pytest.mark.asyncio
+async def test_resolve_providers_accept_legacy_flag_uses_legacy_payload():
+    """P0-G end-to-end — when the flag is on and ``providers=""``, the
+    resolver MUST fall back to the legacy ``providers_json`` payload
+    (stripped of api_key) and resolve keys server-side.
+    """
+    from app.config import settings as _settings
+
+    saved = _settings.ACCEPT_LEGACY_PROVIDERS_JSON
+    _settings.ACCEPT_LEGACY_PROVIDERS_JSON = True
+    try:
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        db = AsyncMock()
+        request = MagicMock()
+        request.headers = {"user-agent": "AutoApply-Chrome-Ext/0.9.0"}
+
+        async def fake_resolve(uid, name, db):
+            return DecryptedKey("sk-server-resolved") if name == "anthropic" else None
+
+        with patch(
+            "app.services.user_provider_configs.resolve_decrypted_key",
+            side_effect=fake_resolve,
+        ):
+            out = await _resolve_providers(
+                providers="",
+                db=db,
+                user=user,
+                providers_json='[{"name":"anthropic","model":"claude-3","api_key":"sk-LEAK"}]',
+                request=request,
+            )
+    finally:
+        _settings.ACCEPT_LEGACY_PROVIDERS_JSON = saved
+
+    assert len(out) == 1
+    assert out[0]["name"] == "anthropic"
+    # The key came from the server-side resolver — NOT from the leaked
+    # legacy payload.
+    assert out[0]["api_key"].expose() == "sk-server-resolved"
+    assert out[0]["api_key"].expose() != "sk-LEAK"
+
+
+@pytest.mark.asyncio
+async def test_resolve_providers_strict_mode_default_rejects_legacy():
+    """P0-G default — flag off (default), legacy payload is rejected
+    with 422 just like before."""
+    from app.config import settings as _settings
+
+    # Default must be False — the assertion both documents the default
+    # and guards against operator misconfiguration.
+    assert _settings.ACCEPT_LEGACY_PROVIDERS_JSON is False
+
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_providers(
+            providers="",
+            db=db,
+            user=user,
+            providers_json='[{"name":"anthropic","api_key":"sk-LEAK"}]',
+        )
+    assert exc_info.value.status_code == 422

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -624,3 +624,74 @@ async def test_resolve_providers_never_logs_plaintext():
     # The plaintext must NOT appear in any rendered log line.
     assert "sk-PLAINTEXT-LEAK-CHECK" not in log_output
     assert "[REDACTED]" in log_output
+
+
+# ---------------------------------------------------------------------------
+# Issue #197 P1-F + P0-G — legacy rejection logs WARN with user/UA, and
+# the ACCEPT_LEGACY_PROVIDERS_JSON transition flag has both modes covered.
+# ---------------------------------------------------------------------------
+
+
+def _install_fresh_loguru_sink():
+    """Return ``(sink, restore)`` — a StringIO sink wired into a fresh
+    loguru logger. Some sibling tests permanently stub ``loguru.logger``
+    with a ``SimpleNamespace`` of no-ops, so we install our own logger
+    for the duration of these tests.
+    """
+    import loguru as _loguru_mod
+    from loguru._logger import Core as _Core
+    from loguru._logger import Logger as _Logger
+
+    saved = _loguru_mod.logger
+    fresh = _Logger(_Core(), None, 0, False, False, False, False, True, [], {})
+    _loguru_mod.logger = fresh
+
+    # Re-bind the loguru import inside _shared so its module-level
+    # ``logger`` points at our fresh instance for the duration of the
+    # test. (Loguru is process-singleton-by-convention but each module
+    # captures a reference at import time.)
+    import app.routers.vault._shared as _shared_mod
+
+    saved_shared_logger = _shared_mod.logger
+    _shared_mod.logger = fresh
+
+    sink = io.StringIO()
+    handler_id = fresh.add(sink, format="{level}|{message}", level="DEBUG")
+
+    def restore() -> None:
+        fresh.remove(handler_id)
+        _loguru_mod.logger = saved
+        _shared_mod.logger = saved_shared_logger
+
+    return sink, restore
+
+
+def test_reject_providers_json_logs_warning_with_user_and_user_agent():
+    """P1-F — every legacy-field rejection must log a WARN line carrying
+    the user id and the request User-Agent so operators can identify
+    which extension installs are still on the old contract.
+    """
+    sink, restore = _install_fresh_loguru_sink()
+    try:
+        user_id = uuid.uuid4()
+        request = MagicMock()
+        request.headers = {"user-agent": "AutoApply-Chrome-Ext/1.2.3"}
+
+        with pytest.raises(HTTPException) as exc_info:
+            _reject_providers_json(
+                '[{"name":"groq","api_key":"gsk_x"}]',
+                user_id=user_id,
+                request=request,
+            )
+        assert exc_info.value.status_code == 422
+
+        log_output = sink.getvalue()
+    finally:
+        restore()
+
+    assert "WARNING" in log_output
+    assert "legacy_providers_json_rejected" in log_output
+    assert str(user_id) in log_output
+    assert "AutoApply-Chrome-Ext/1.2.3" in log_output
+
+

--- a/backend/tests/unit/test_vault_provider_contract.py
+++ b/backend/tests/unit/test_vault_provider_contract.py
@@ -880,3 +880,121 @@ def test_accept_legacy_providers_json_default_is_true():
 
     fresh = Settings()
     assert fresh.ACCEPT_LEGACY_PROVIDERS_JSON is True
+
+
+# ---------------------------------------------------------------------------
+# P2 (round-3) — User-Agent log CRLF sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_log_value_escapes_crlf_and_caps_length():
+    """A malicious ``User-Agent`` like ``foo\\r\\nLevel:INFO ...`` must not
+    produce a second physical log line. ``_sanitize_log_value`` escapes
+    CR/LF to literal two-character sequences and caps at 200 chars."""
+    from app.routers.vault._shared import _sanitize_log_value
+
+    # Empty / None pass through.
+    assert _sanitize_log_value(None) == ""
+    assert _sanitize_log_value("") == ""
+
+    # CR / LF / CRLF all escaped to literal backslash sequences.
+    assert _sanitize_log_value("a\nb") == "a\\nb"
+    assert _sanitize_log_value("a\rb") == "a\\rb"
+    assert (
+        _sanitize_log_value("foo\r\nLevel:INFO Message:fake") == "foo\\r\\nLevel:INFO Message:fake"
+    )
+
+    # Length cap at 200.
+    blob = "x" * 500
+    out = _sanitize_log_value(blob)
+    assert len(out) == 200
+    assert out == "x" * 200
+
+
+def test_reject_providers_json_strict_log_sanitizes_user_agent():
+    """P2 (round-3) — when a legacy client sends a CRLF-laced
+    ``User-Agent``, the strict-mode WARN log line must contain the
+    escaped form (``\\r\\n``) and MUST NOT contain a real newline +
+    "Level:INFO" prefix that loguru would render as a second line.
+    """
+    restore_flag = _flip_accept_legacy_flag(False)
+    sink, restore_log = _install_fresh_loguru_sink()
+    try:
+        user_id = uuid.uuid4()
+        request = MagicMock()
+        request.headers = {"user-agent": "evil\r\nLevel:INFO Message:injected"}
+
+        with pytest.raises(HTTPException):
+            _reject_providers_json(
+                '[{"name":"groq","api_key":"gsk_x"}]',
+                user_id=user_id,
+                request=request,
+            )
+
+        log_output = sink.getvalue()
+    finally:
+        restore_log()
+        restore_flag()
+
+    assert "legacy_providers_json_rejected" in log_output
+    # Escaped form is present.
+    assert "evil\\r\\nLevel:INFO Message:injected" in log_output
+    # And the raw injection sequence (real newline followed by "Level:INFO")
+    # is NOT present anywhere in the captured output.
+    assert "evil\r\nLevel:INFO" not in log_output
+
+
+def test_reject_providers_json_accept_flag_log_sanitizes_user_agent():
+    """P2 (round-3) — same sanitization for the soft-reject (accept)
+    log line so an attacker can't forge a fake log entry through the
+    transition window either."""
+    restore_flag = _flip_accept_legacy_flag(True)
+    sink, restore_log = _install_fresh_loguru_sink()
+    try:
+        user_id = uuid.uuid4()
+        request = MagicMock()
+        request.headers = {"user-agent": "evil\r\nLevel:ERROR Message:fake"}
+
+        # Soft mode — must not raise.
+        _reject_providers_json(
+            '[{"name":"groq","api_key":"gsk_x"}]',
+            user_id=user_id,
+            request=request,
+        )
+
+        log_output = sink.getvalue()
+    finally:
+        restore_log()
+        restore_flag()
+
+    assert "legacy_providers_json_accepted" in log_output
+    assert "evil\\r\\nLevel:ERROR Message:fake" in log_output
+    assert "evil\r\nLevel:ERROR" not in log_output
+
+
+def test_reject_providers_json_caps_oversized_user_agent_in_log():
+    """A pathological multi-kilobyte User-Agent should be capped at 200
+    chars in the log line so the log pipeline can't be DoS'd."""
+    restore_flag = _flip_accept_legacy_flag(False)
+    sink, restore_log = _install_fresh_loguru_sink()
+    try:
+        user_id = uuid.uuid4()
+        request = MagicMock()
+        request.headers = {"user-agent": "A" * 5000}
+
+        with pytest.raises(HTTPException):
+            _reject_providers_json(
+                '[{"name":"groq","api_key":"gsk_x"}]',
+                user_id=user_id,
+                request=request,
+            )
+
+        log_output = sink.getvalue()
+    finally:
+        restore_log()
+        restore_flag()
+
+    # The capped 200-char "A" run is present...
+    assert "A" * 200 in log_output
+    # ...but not the full 5000-char one.
+    assert "A" * 201 not in log_output


### PR DESCRIPTION
## Summary

Closes the #197 P0: extension was leaking the user's encrypted LLM key in the request body. Backend now resolves keys server-side from encrypted vault.

- **Key resolution path**: new `app/services/user_provider_configs.py::resolve_decrypted_key` decrypts per-user provider keys via Fernet, called from `app/routers/vault/_shared.py::_resolve_providers`.
- **Legacy compatibility**: `ACCEPT_LEGACY_PROVIDERS_JSON` flag (defaults to `True`) accepts old `providers_json` form field, strips any `api_key`, then resolves server-side. Logs `legacy_providers_json_accepted` for visibility into rollout.
- **Log hardening (rounds 3 + 4)**: new `app/utils/log_safety.py::sanitize_log_value` (CRLF escape, 200-char cap, None-safe). Applied to user-controlled inputs in `_shared.py` (UA, `row.provider_name`) and `user_provider_configs.py` (decrypt-failure + provider_skipped sites).

Cross-cutting follow-up filed as #237 to apply `sanitize_log_value` across the rest of the codebase.

## Test plan

- [x] `backend/tests/unit/test_resolve_decrypted_key.py` — 13 pass (CRLF sanitization, decrypt-failure path, helper contract)
- [x] `backend/tests/unit/test_vault_provider_contract.py` — covers strict-mode rejection of api_key on wire
- [x] `backend/tests/unit/test_decrypted_key.py` — Fernet round-trip
- [x] ruff / black / mypy clean on touched files
- [x] Verified by 4 rounds of independent critic agents — 5/6 final critics PASS, 1 PASS-WITH-GAPS (out-of-scope; tracked in #237)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7CXtKWcq3aiYmUEPMTJcu)_